### PR TITLE
Fix empty list bug

### DIFF
--- a/pkg/api/selected_map_list.go
+++ b/pkg/api/selected_map_list.go
@@ -90,6 +90,13 @@ func unmarshalJSON(data []byte) ([]string, error) {
 
 	err := json.Unmarshal(data, &dataMap)
 	if err != nil {
+		// If we fail, it's very likely data contains [], so try that
+		var emptyList []string
+		if listErr := json.Unmarshal(data, &emptyList); listErr == nil {
+			// If we parsed without error, then assume list is empty
+			return []string{}, nil
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
OPNsense will respond to a request with either a JSON object, which was parsed correctly with SelectedMapList, or an empty array, which would fail on an unmarshal attempt.


As raised in this issue: https://github.com/browningluke/terraform-provider-opnsense/issues/28#issue-1883771923 (section 2), if the remote OPNsense has no configured categories, OPNsense will respond to an Alias GET with Alias.categories set to [], which caused the crash.

This PR fixes that bug.