### PR TITLE
Add diagnostics interface read-only resource

### DIFF
--- a/pkg/diagnostics/controller.go
+++ b/pkg/diagnostics/controller.go
@@ -1,0 +1,12 @@
+package diagnostics
+
+import "github.com/browningluke/opnsense-go/pkg/api"
+
+// Controller for diagnostics
+type Controller struct {
+	Api *api.Client
+}
+
+func (c *Controller) Client() *api.Client {
+	return c.Api
+}

--- a/pkg/diagnostics/interface.go
+++ b/pkg/diagnostics/interface.go
@@ -1,0 +1,58 @@
+package diagnostics
+
+import (
+	"context"
+	"github.com/browningluke/opnsense-go/pkg/api"
+)
+
+var InterfaceOpts = api.ReqOpts{
+	AddEndpoint:         "",
+	GetEndpoint:         "/diagnostics/interface/getInterfaceConfig",
+	UpdateEndpoint:      "",
+	DeleteEndpoint:      "",
+	ReconfigureEndpoint: "",
+	Monad:               "",
+}
+
+// Data structs
+
+type Ipv4Config struct {
+	IpAddr     string `json:"ipaddr"`
+	SubnetBits int64  `json:"subnetbits"`
+	Tunnel     bool   `json:"tunnel"`
+}
+
+type Ipv6Config struct {
+	IpAddr     string `json:"ipaddr"`
+	SubnetBits int64  `json:"subnetbits"`
+	Tunnel     bool   `json:"tunnel"`
+	Autoconf   bool   `json:"autoconf"`
+	Deprecated bool   `json:"deprecated"`
+	LinkLocal  bool   `json:"link-local"`
+	Tentative  bool   `json:"tentative"`
+}
+
+type Interface struct {
+	Device     string `json:"device"`
+	Media      string `json:"media"`
+	MediaRaw   string `json:"media_raw"`
+	MacAddr    string `json:"macaddr"`
+	IsPhysical bool   `json:"is_physical"`
+	MTU        string `json:"mtu"`
+	Status     string `json:"status"`
+
+	Flags          []string `json:"flags"`
+	Capabilities   []string `json:"capabilities"`
+	Options        []string `json:"options"`
+	SupportedMedia []string `json:"supported_media"`
+	Groups         []string `json:"groups"`
+
+	Ipv4 []Ipv4Config `json:"ipv4"`
+	Ipv6 []Ipv6Config `json:"ipv6"`
+}
+
+// CRUD operations
+
+func (c *Controller) GetInterface(ctx context.Context, id string) (*Interface, error) {
+	return api.GetFilter(c.Client(), ctx, InterfaceOpts, &Interface{}, id)
+}

--- a/pkg/opnsense/client.go
+++ b/pkg/opnsense/client.go
@@ -2,6 +2,7 @@ package opnsense
 
 import (
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/diagnostics"
 	"github.com/browningluke/opnsense-go/pkg/firewall"
 	"github.com/browningluke/opnsense-go/pkg/interfaces"
 	"github.com/browningluke/opnsense-go/pkg/quagga"
@@ -12,6 +13,7 @@ import (
 
 // Client defines a client interface for the Proxmox Virtual Environment API.
 type Client interface {
+	Diagnostics() *diagnostics.Controller
 	Unbound() *unbound.Controller
 	Wireguard() *wireguard.Controller
 	Quagga() *quagga.Controller
@@ -27,6 +29,10 @@ type client struct {
 // NewClient creates a new API client.
 func NewClient(a *api.Client) Client {
 	return &client{a: a}
+}
+
+func (c *client) Diagnostics() *diagnostics.Controller {
+	return &diagnostics.Controller{Api: c.a}
 }
 
 func (c *client) Unbound() *unbound.Controller {


### PR DESCRIPTION
This PR adds the Interface read-only resource from the OPNsense diagnostics controller (https://docs.opnsense.org/development/api/core/diagnostics.html)

Massive thank you to @rcloran for doing the main legwork on this: https://github.com/browningluke/terraform-provider-opnsense/issues/33 and https://github.com/rcloran/opnsense-go/commit/2f1767a54c40e37c561d1f58aa0a739db2b0fba1

I just refactored it slightly to standardize it with the other resources, which should make it easier to auto-generate. 