### PR TITLE
Feature/kea subnet match client

### DIFF
--- a/pkg/kea/subnet.go
+++ b/pkg/kea/subnet.go
@@ -34,7 +34,7 @@ type Subnet struct {
 	Subnet                string     `json:"subnet"`
 	NextServer            string     `json:"next_server"`
 	Pools                 string     `json:"pools"`
-	MatchClientId         string     `json:"match_client_id"`
+	MatchClientId         string     `json:"match-client-id"`
 	OptionDataAutoCollect string     `json:"option_data_autocollect"`
 	OptionData            OptionData `json:"option_data"`
 	Description           string     `json:"description"`

--- a/schema/kea.yml
+++ b/schema/kea.yml
@@ -22,7 +22,7 @@ resources:
         key: pools
       - name: MatchClientId
         type: string
-        key: match_client_id
+        key: match-client-id
       - name: OptionDataAutoCollect
         type: string
         key: option_data_autocollect


### PR DESCRIPTION
Added the field match-client-id for kea subnet to be able to set this to `false` in my terraform projects. This is needed to get kea reservations working with matching on mac address instead of client-id.

For example when staging K8S Harvester nodes by PXE boot, the nodes changing their client-id during setup and like this, DHCP reservations are not working. I have to manually disable match-client-id in GUI during my Terraform apply run before Harvester nodes are starting.

I have also adjusted your terraform provider terraform-provider-opnsense to make use of this new field. I will create a pull request for this as well.

<img width="606" height="604" alt="image" src="https://github.com/user-attachments/assets/688e4fa2-6115-4de9-9d65-6f5b86e2873a" />
