### PR TITLE
Configure HTTP client with proxy support

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -59,6 +59,7 @@ func NewClient(options Options) *Client {
 
 	// Configure HTTP client
 	client.client.HTTPClient.Transport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: options.AllowInsecure},
 	}
 


### PR DESCRIPTION
**What:** Adds http.ProxyFromEnvironment to the HTTP transport.
**Why:** Enables users to route API requests through HTTP, HTTPS, or SOCKS5 proxies by setting standard environment variables (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY, NO_PROXY).
**Impact:** Single-line change, no breaking API changes, no new dependencies.

Relevant issue: https://github.com/browningluke/opnsense-go/issues/46