### PR TITLE
ci: add make generate check workflow

### DIFF
--- a/.github/workflows/make-generate-check.yml
+++ b/.github/workflows/make-generate-check.yml
@@ -5,10 +5,10 @@ on:
     paths-ignore:
       - 'scripts/**'
       - 'README.md'
-      - '.github/**'
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   check-make-generate:
@@ -28,9 +28,46 @@ jobs:
         run: make all
 
       - name: Check for uncommitted changes
+        id: diff
         run: |
-          if ! git diff --exit-code; then
-            echo "⚠️ 'make all' resulted in changes. Please run 'make all' and commit the results."
-            git diff
-            exit 1
+          if git diff --exit-code; then
+            echo "clean=true" >> $GITHUB_OUTPUT
+          else
+            echo "clean=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Find existing sticky comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: <!-- make-generate-check -->
+
+      - name: Post or update failure comment
+        if: steps.diff.outputs.clean == 'false'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- make-generate-check -->
+            ## ⚠️ Generated files are out of date
+
+            Running `make all` produced uncommitted changes. Please run `make all` locally and commit the results.
+
+            See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full diff.
+          edit-mode: replace
+
+      - name: Delete resolved sticky comment
+        if: steps.diff.outputs.clean == 'true' && steps.find-comment.outputs.comment-id != ''
+        run: gh api repos/${{ github.repository }}/issues/comments/${{ steps.find-comment.outputs.comment-id }} -X DELETE
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fail if changes detected
+        if: steps.diff.outputs.clean == 'false'
+        run: |
+          echo "⚠️ 'make all' resulted in changes. Please run 'make all' and commit the results."
+          git diff
+          exit 1

--- a/.github/workflows/make-generate-check.yml
+++ b/.github/workflows/make-generate-check.yml
@@ -1,0 +1,36 @@
+name: Make Generate Check
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'scripts/**'
+      - 'README.md'
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-make-generate:
+    name: Ensure all modules are generated
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run make all
+        run: make all
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "⚠️ 'make all' resulted in changes. Please run 'make all' and commit the results."
+            git diff
+            exit 1
+          fi

--- a/internal/generate/api/templates/resource.tmpl
+++ b/internal/generate/api/templates/resource.tmpl
@@ -4,6 +4,7 @@ package {{ .Controller.Name }}
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/internal/generate/api/templates/rpc.tmpl
+++ b/internal/generate/api/templates/rpc.tmpl
@@ -4,7 +4,8 @@ package {{ .Controller.Name }}
 
 import (
 	"context"
-    "fmt"    
+	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/auth/group.go
+++ b/pkg/auth/group.go
@@ -4,6 +4,7 @@ package auth
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/auth/privilege.go
+++ b/pkg/auth/privilege.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/auth/privilege_search.go
+++ b/pkg/auth/privilege_search.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/auth/user_api_key.go
+++ b/pkg/auth/user_api_key.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/auth/user_otp.go
+++ b/pkg/auth/user_otp.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/bind/acl.go
+++ b/pkg/bind/acl.go
@@ -4,6 +4,7 @@ package bind
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/bind/primary_domain.go
+++ b/pkg/bind/primary_domain.go
@@ -4,6 +4,7 @@ package bind
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/bind/record.go
+++ b/pkg/bind/record.go
@@ -4,6 +4,7 @@ package bind
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -5,6 +5,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -5,6 +5,7 @@ package core
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/diagnostics/interface.go
+++ b/pkg/diagnostics/interface.go
@@ -4,6 +4,7 @@ package diagnostics
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/boot.go
+++ b/pkg/dnsmasq/boot.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/domain.go
+++ b/pkg/dnsmasq/domain.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/general.go
+++ b/pkg/dnsmasq/general.go
@@ -5,6 +5,7 @@ package dnsmasq
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/host.go
+++ b/pkg/dnsmasq/host.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/option.go
+++ b/pkg/dnsmasq/option.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/range.go
+++ b/pkg/dnsmasq/range.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/search.go
+++ b/pkg/dnsmasq/search.go
@@ -5,6 +5,7 @@ package dnsmasq
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/service.go
+++ b/pkg/dnsmasq/service.go
@@ -5,6 +5,7 @@ package dnsmasq
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dnsmasq/tag.go
+++ b/pkg/dnsmasq/tag.go
@@ -4,6 +4,7 @@ package dnsmasq
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dyndns/account.go
+++ b/pkg/dyndns/account.go
@@ -4,6 +4,7 @@ package dyndns
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/dyndns/service.go
+++ b/pkg/dyndns/service.go
@@ -5,6 +5,7 @@ package dyndns
 import (
 	"context"
 	"fmt"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/firewall/alias.go
+++ b/pkg/firewall/alias.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/firewall/category.go
+++ b/pkg/firewall/category.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/firewall/filter.go
+++ b/pkg/firewall/filter.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/firewall/nat.go
+++ b/pkg/firewall/nat.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/firewall/nat_one_to_one.go
+++ b/pkg/firewall/nat_one_to_one.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/interfaces/assign.go
+++ b/pkg/interfaces/assign.go
@@ -4,6 +4,7 @@ package interfaces
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/interfaces/vip.go
+++ b/pkg/interfaces/vip.go
@@ -4,6 +4,7 @@ package interfaces
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/interfaces/vlan.go
+++ b/pkg/interfaces/vlan.go
@@ -4,6 +4,7 @@ package interfaces
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_auth_local.go
+++ b/pkg/ipsec/ipsec_auth_local.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_auth_remote.go
+++ b/pkg/ipsec/ipsec_auth_remote.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_child.go
+++ b/pkg/ipsec/ipsec_child.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_connection.go
+++ b/pkg/ipsec/ipsec_connection.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_psk.go
+++ b/pkg/ipsec/ipsec_psk.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/ipsec/ipsec_vti.go
+++ b/pkg/ipsec/ipsec_vti.go
@@ -4,6 +4,7 @@ package ipsec
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/kea/peer.go
+++ b/pkg/kea/peer.go
@@ -4,6 +4,7 @@ package kea
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/kea/reservation.go
+++ b/pkg/kea/reservation.go
@@ -4,6 +4,7 @@ package kea
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/kea/subnet.go
+++ b/pkg/kea/subnet.go
@@ -4,6 +4,7 @@ package kea
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/quagga/bgp_aspath.go
+++ b/pkg/quagga/bgp_aspath.go
@@ -4,6 +4,7 @@ package quagga
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/quagga/bgp_communitylist.go
+++ b/pkg/quagga/bgp_communitylist.go
@@ -4,6 +4,7 @@ package quagga
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/quagga/bgp_neighbor.go
+++ b/pkg/quagga/bgp_neighbor.go
@@ -4,6 +4,7 @@ package quagga
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/quagga/bgp_prefixlist.go
+++ b/pkg/quagga/bgp_prefixlist.go
@@ -4,6 +4,7 @@ package quagga
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/quagga/bgp_routemap.go
+++ b/pkg/quagga/bgp_routemap.go
@@ -4,6 +4,7 @@ package quagga
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/routes/route.go
+++ b/pkg/routes/route.go
@@ -4,6 +4,7 @@ package routes
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/unbound/domain_override.go
+++ b/pkg/unbound/domain_override.go
@@ -4,6 +4,7 @@ package unbound
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/unbound/forward.go
+++ b/pkg/unbound/forward.go
@@ -4,6 +4,7 @@ package unbound
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/unbound/host_alias.go
+++ b/pkg/unbound/host_alias.go
@@ -4,6 +4,7 @@ package unbound
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/unbound/host_override.go
+++ b/pkg/unbound/host_override.go
@@ -4,6 +4,7 @@ package unbound
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/wireguard/client.go
+++ b/pkg/wireguard/client.go
@@ -4,6 +4,7 @@ package wireguard
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 

--- a/pkg/wireguard/server.go
+++ b/pkg/wireguard/server.go
@@ -4,6 +4,7 @@ package wireguard
 
 import (
 	"context"
+
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 


### PR DESCRIPTION
Adds a PR workflow that runs `make all` and fails if any generated module files are out of date, mirroring the `go-generate-check` workflow in `terraform-provider-opnsense`.