### PR TITLE
ci: implement tiered test system

### DIFF
--- a/.github/workflows/go-test-pr.yml
+++ b/.github/workflows/go-test-pr.yml
@@ -1,0 +1,91 @@
+name: PR Tests (Tier 1)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!scripts/**'
+      - '!README.md'
+      - '.github/workflows/go-test-pr.yml'
+      - '.github/workflows/go-test-reusable.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: git fetch origin main --depth=1
+
+      - name: Detect changed packages
+        id: detect
+        run: |
+          ALL_CHANGED=$(git diff --name-only origin/main...HEAD)
+
+          # Check for any Go source or module file changes
+          GO_FILES=$(echo "$ALL_CHANGED" | grep '\.go$' || true)
+          MOD_CHANGED=$(echo "$ALL_CHANGED" | grep -E '^go\.(mod|sum)$' || true)
+
+          if [ -z "$GO_FILES" ] && [ -z "$MOD_CHANGED" ]; then
+            echo "No Go files changed — skipping tests"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$MOD_CHANGED" ]; then
+            echo "go.mod/go.sum changed — running full suite"
+            echo "packages=./..." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Core packages: changes here affect all modules
+          CORE_CHANGED=$(echo "$GO_FILES" | grep -E '^(pkg/api/|pkg/errs/|pkg/opnsense/|internal/)' || true)
+          if [ -n "$CORE_CHANGED" ]; then
+            echo "Core files changed — running full suite"
+            echo "packages=./..." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Map changed pkg/{name}/ and schema/{name}.yml to ./pkg/{name}/...
+          PKG_NAMES=""
+
+          PKG_CHANGED=$(echo "$GO_FILES" | grep '^pkg/' | sed 's|^pkg/\([^/]*\)/.*|\1|' | sort -u || true)
+          for name in $PKG_CHANGED; do
+            PKG_NAMES="$PKG_NAMES $name"
+          done
+
+          SCHEMA_CHANGED=$(echo "$ALL_CHANGED" | grep '^schema/.*\.yml$' | sed 's|^schema/\(.*\)\.yml$|\1|' | sort -u || true)
+          for name in $SCHEMA_CHANGED; do
+            PKG_NAMES="$PKG_NAMES $name"
+          done
+
+          PKG_NAMES=$(echo "$PKG_NAMES" | tr ' ' '\n' | sort -u | grep -v '^$' || true)
+
+          if [ -z "$PKG_NAMES" ]; then
+            echo "No relevant packages detected — skipping tests"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PACKAGES=$(echo "$PKG_NAMES" | sed 's|^|./pkg/|; s|$|/...|' | tr '\n' ' ' | sed 's/ $//')
+          echo "Changed packages: ${PACKAGES}"
+          echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.packages != ''
+    uses: ./.github/workflows/go-test-reusable.yml
+    with:
+      packages: ${{ needs.detect-changes.outputs.packages }}

--- a/.github/workflows/go-test-prerelease.yml
+++ b/.github/workflows/go-test-prerelease.yml
@@ -1,0 +1,21 @@
+name: Pre-release Tests (Tier 3)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manually triggering this workflow'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    uses: ./.github/workflows/go-test-reusable.yml
+    with:
+      packages: './...'

--- a/.github/workflows/go-test-reusable.yml
+++ b/.github/workflows/go-test-reusable.yml
@@ -1,0 +1,93 @@
+name: Run go tests (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: 'Go packages to test (e.g. ./... or ./pkg/firewall/...)'
+        type: string
+        default: './...'
+
+permissions:
+  contents: read
+
+env:
+  OPNSENSE_VERSION: "26.1"
+  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
+  OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
+  OPNSENSE_SSH_PORT: 8022
+  OPNSENSE_WEB_PORT: 8443
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Create opnsense image directory
+        run: mkdir -p opnsense-images
+
+      - name: Download OPNsense image
+        run: curl -L "$OPNSENSE_URL" -o opnsense-images/opnsense.qcow2
+
+      - name: Verify OPNsense image
+        run: echo "$OPNSENSE_SHA1  opnsense-images/opnsense.qcow2" | sha1sum -c -
+
+      - name: Disable triggers
+        run: |
+          mkdir -p /etc/dpkg/dpkg.cfg.d
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
+          EOF
+
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86
+
+      - name: Start opnsense VM
+        id: start-vm
+        run: |
+          qemu-system-x86_64 -m 6144 -smp 2 -hda opnsense-images/opnsense.qcow2 \
+          -netdev user,id=user.0,hostfwd=tcp::${{ env.OPNSENSE_SSH_PORT }}-:22,hostfwd=tcp::${{ env.OPNSENSE_WEB_PORT }}-:443 \
+          -device virtio-net,netdev=user.0 \
+          -chardev socket,path=/tmp/qemu-isa-serial.sock,server=on,wait=off,id=qga0 \
+          -device isa-serial,chardev=qga0 \
+          -device virtio-serial \
+          -chardev socket,path=/tmp/qemu-virtconsole.sock,server=on,wait=off,id=qvt0 \
+          -device virtconsole,chardev=qvt0 \
+          -chardev socket,path=/tmp/qemu-virtserialport.sock,server=on,wait=off,id=qvsp0 \
+          -device virtserialport,chardev=qvsp0,name=org.qemu.guest_agent.0 \
+          -nographic &
+          QEMU_PID="$!"
+          echo "qemu-pid=${QEMU_PID}" >> "$GITHUB_OUTPUT"
+          sleep 180 # Wait for the VM to boot
+          [ -d "/proc/${QEMU_PID}" ] || (echo "QEMU process not found" && exit 1)
+
+      - name: Create API key
+        id: apikey
+        run: python3 scripts/create-apikey.py 2> "$GITHUB_OUTPUT"
+
+      - name: Setup env vars for tests
+        run: |
+          {
+            echo "OPNSENSE_API_KEY=${{ steps.apikey.outputs.key }}";
+            echo "OPNSENSE_API_SECRET=${{ steps.apikey.outputs.secret }}";
+            echo "OPNSENSE_URI=https://localhost:${{ env.OPNSENSE_WEB_PORT }}";
+            echo "OPNSENSE_ALLOW_INSECURE=true";
+          } >> "$GITHUB_ENV"
+
+      - name: Run tests
+        run: go test -p 1 -v ${{ inputs.packages }}
+
+      - name: Stop opnsense VM
+        if: always()
+        run: kill -9 ${{ steps.start-vm.outputs.qemu-pid }} || true

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,84 +1,20 @@
-name: Run go tests
+name: Post-merge Tests (Tier 2)
+
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-env:
-  OPNSENSE_VERSION: "26.1"
-  OPNSENSE_URL: "https://files.bsd.ac/opnsense-qemu/opnsense-26.1.qcow2"
-  OPNSENSE_SHA1: 2266a644b1669be1a8d916a0a79fc91ba4be4733
-  OPNSENSE_SSH_PORT: 8022
-  OPNSENSE_WEB_PORT: 8443
+    paths-ignore:
+      - 'scripts/**'
+      - 'README.md'
+      - '.github/**'
+
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        parallelism: 
-          - "1"
-          # - "$(nproc)"  # 'go test' creates processes which don't work with the mutex
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: Create opnsense image directory
-        run: |
-          mkdir -p opnsense-images
-      - name: Download OPNsense image
-        run: |
-          curl -L $OPNSENSE_URL -o opnsense-images/opnsense.qcow2
-      - name: Verify OPNsense image
-        run: |
-          echo "$OPNSENSE_SHA1  opnsense-images/opnsense.qcow2" | sha1sum -c -
-      - name: Disable triggers
-        run: |
-          mkdir -p /etc/dpkg/dpkg.cfg.d
-          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
-          path-exclude /usr/share/doc/*
-          path-exclude /usr/share/man/*
-          path-exclude /usr/share/info/*
-          EOF
-      - name: Install qemu
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-x86
-      - name: Start opnsense VM
-        id: start-vm
-        run: |
-          qemu-system-x86_64 -m 6144 -smp 2 -hda opnsense-images/opnsense.qcow2 \
-          -netdev user,id=user.0,hostfwd=tcp::${{ env.OPNSENSE_SSH_PORT }}-:22,hostfwd=tcp::${{ env.OPNSENSE_WEB_PORT }}-:443 \
-          -device virtio-net,netdev=user.0 \
-          -chardev socket,path=/tmp/qemu-isa-serial.sock,server=on,wait=off,id=qga0 \
-          -device isa-serial,chardev=qga0 \
-          -device virtio-serial \
-          -chardev socket,path=/tmp/qemu-virtconsole.sock,server=on,wait=off,id=qvt0 \
-          -device virtconsole,chardev=qvt0 \
-          -chardev socket,path=/tmp/qemu-virtserialport.sock,server=on,wait=off,id=qvsp0 \
-          -device virtserialport,chardev=qvsp0,name=org.qemu.guest_agent.0 \
-          -nographic &
-          QEMU_PID=$!
-          echo "qemu-pid=${QEMU_PID}" >> $GITHUB_OUTPUT
-          sleep 180 # Wait for the VM to boot
-          [ -d "/proc/${QEMU_PID}" ] || (echo "QEMU process not found" && exit 1)
-      - name: Create API key
-        id: apikey
-        run: |
-          python3 scripts/create-apikey.py 2> $GITHUB_OUTPUT
-      - name: Setup env vars for tests
-        run: |
-          echo "OPNSENSE_API_KEY=${{ steps.apikey.outputs.key }}" >> $GITHUB_ENV
-          echo "OPNSENSE_API_SECRET=${{ steps.apikey.outputs.secret }}" >> $GITHUB_ENV
-          echo "OPNSENSE_URI=https://localhost:${{ env.OPNSENSE_WEB_PORT }}" >> $GITHUB_ENV
-      - name: Run tests
-        run: |
-          go test -p "${{ matrix.parallelism }}" -v ./...
-      - name: Stop opnsense VM
-        run: |
-          kill -9 ${{ steps.start-vm.outputs.qemu-pid }}
+    uses: ./.github/workflows/go-test-reusable.yml
+    with:
+      packages: './...'
+


### PR DESCRIPTION
Replaces the single monolithic `go-test.yml` with a three-tier system mirroring `terraform-provider-opnsense`.

**Tier 1** (`go-test-pr.yml`) — PR only, change detection:
- `go.mod`/`go.sum` changed → full `./...`
- Core files (`pkg/api/`, `pkg/errs/`, `pkg/opnsense/`, `internal/`) changed → full `./...`
- `pkg/{name}/` or `schema/{name}.yml` changed → `./pkg/{name}/...` only
- No relevant changes → skip (no VM spun up at all)

**Tier 2** (`go-test.yml`) — push to `main`, always `./...`

**Tier 3** (`go-test-prerelease.yml`) — `v*` tags + `workflow_dispatch`, always `./...`

All tiers call the shared `go-test-reusable.yml` which accepts a `packages` input.

Also fixes two issues vs the old `go-test.yml`: adds `OPNSENSE_ALLOW_INSECURE=true` and adds `if: always()` to the VM stop step to prevent leaked VMs on failure.