### PR TITLE
ci: dispatch provider dependency bump on release

### DIFF
--- a/.github/workflows/dispatch-provider-bump.yml
+++ b/.github/workflows/dispatch-provider-bump.yml
@@ -1,0 +1,34 @@
+name: Dispatch Provider Dependency Bump
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to terraform-provider-opnsense
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+        run: |
+          jq -n \
+            --arg version "$VERSION" \
+            --arg release_url "$RELEASE_URL" \
+            --arg release_name "$RELEASE_NAME" \
+            '{
+              event_type: "opnsense-go-release",
+              client_payload: {
+                version: $version,
+                release_url: $release_url,
+                release_name: $release_name
+              }
+            }' | gh api repos/browningluke/terraform-provider-opnsense/dispatches \
+                    --method POST \
+                    --input -


### PR DESCRIPTION
## Summary

Adds a workflow that fires whenever a new `opnsense-go` release is published. It sends a `repository_dispatch` event to `terraform-provider-opnsense`, which triggers an automated PR to bump the dependency version there.

## How it works

1. A release is published in this repo
2. This workflow dispatches an `opnsense-go-release` event to `terraform-provider-opnsense`, passing the version tag, release URL, and release name
3. The provider repo opens a PR bumping `go.mod`/`go.sum` and enables auto-merge

## Required setup

A secret named `AUTOMATION_TOKEN` must be added to this repository — a fine-grained PAT scoped to `terraform-provider-opnsense` with **Contents: Read & Write** and **Pull requests: Read & Write** permissions.

Links to [terraform-provider-opnsense#108](https://github.com/browningluke/terraform-provider-opnsense/pull/108)