### PR TITLE
Update lagg options and stastics

### DIFF
--- a/pkg/interfaces/overview.go
+++ b/pkg/interfaces/overview.go
@@ -129,40 +129,51 @@ type InterfaceIPv6 struct {
 }
 
 type InterfaceInfo struct {
-	Flags             []string        `json:"flags,omitempty"`
-	Capabilities      []string        `json:"capabilities,omitempty"`
-	Options           []string        `json:"options,omitempty"`
-	MacAddr           string          `json:"macaddr,omitempty"`
-	SupportedMedia    []string        `json:"supported_media,omitempty"`
-	IsPhysical        bool            `json:"is_physical,omitempty"`
-	Device            string          `json:"device,omitempty"`
-	MTU               string          `json:"mtu,omitempty"`
-	MacAddrHw         string          `json:"macaddr_hw,omitempty"`
-	Media             string          `json:"media,omitempty"`
-	MediaRaw          string          `json:"media_raw,omitempty"`
-	Status            string          `json:"status,omitempty"`
-	ND6               InterfaceND6    `json:"nd6,omitempty"`
-	Routes            []string        `json:"routes,omitempty"`
-	Config            InterfaceConfig `json:"config,omitempty"`
-	IfctlNameserver   []string        `json:"ifctl.nameserver,omitempty"`
-	IfctlRouter       []string        `json:"ifctl.router,omitempty"`
-	IfctlPrefix       []string        `json:"ifctl.prefix,omitempty"`
-	IfctlSearchdomain []string        `json:"ifctl.searchdomain,omitempty"`
-	Identifier        string          `json:"identifier,omitempty"`
-	Description       string          `json:"description,omitempty"`
-	Enabled           bool            `json:"enabled,omitempty"`
-	LinkType          string          `json:"link_type,omitempty"`
-	Addr4             string          `json:"addr4,omitempty"`
-	Addr6             string          `json:"addr6,omitempty"`
-	IPv4              []InterfaceIPv4 `json:"ipv4,omitempty"`
-	IPv6              []InterfaceIPv6 `json:"ipv6,omitempty"`
-	VLANTag           string          `json:"vlan_tag,omitempty"`
-	Gateways          []string        `json:"gateways,omitempty"`
-	Groups            []string        `json:"groups,omitempty"`
-	VLAN              InterfaceVlan   `json:"vlan,omitempty"`
-	LaggProto         string          `json:"laggproto,omitempty"`
-	LaggHash          string          `json:"lagghash,omitempty"`
-	LaggOptions       string          `json:"laggoptions,omitempty"`
+	Flags             []string                `json:"flags,omitempty"`
+	Capabilities      []string                `json:"capabilities,omitempty"`
+	Options           []string                `json:"options,omitempty"`
+	MacAddr           string                  `json:"macaddr,omitempty"`
+	SupportedMedia    []string                `json:"supported_media,omitempty"`
+	IsPhysical        bool                    `json:"is_physical,omitempty"`
+	Device            string                  `json:"device,omitempty"`
+	MTU               string                  `json:"mtu,omitempty"`
+	MacAddrHw         string                  `json:"macaddr_hw,omitempty"`
+	Media             string                  `json:"media,omitempty"`
+	MediaRaw          string                  `json:"media_raw,omitempty"`
+	Status            string                  `json:"status,omitempty"`
+	ND6               InterfaceND6            `json:"nd6,omitempty"`
+	Routes            []string                `json:"routes,omitempty"`
+	Config            InterfaceConfig         `json:"config,omitempty"`
+	IfctlNameserver   []string                `json:"ifctl.nameserver,omitempty"`
+	IfctlRouter       []string                `json:"ifctl.router,omitempty"`
+	IfctlPrefix       []string                `json:"ifctl.prefix,omitempty"`
+	IfctlSearchdomain []string                `json:"ifctl.searchdomain,omitempty"`
+	Identifier        string                  `json:"identifier,omitempty"`
+	Description       string                  `json:"description,omitempty"`
+	Enabled           bool                    `json:"enabled,omitempty"`
+	LinkType          string                  `json:"link_type,omitempty"`
+	Addr4             string                  `json:"addr4,omitempty"`
+	Addr6             string                  `json:"addr6,omitempty"`
+	IPv4              []InterfaceIPv4         `json:"ipv4,omitempty"`
+	IPv6              []InterfaceIPv6         `json:"ipv6,omitempty"`
+	VLANTag           string                  `json:"vlan_tag,omitempty"`
+	Gateways          []string                `json:"gateways,omitempty"`
+	Groups            []string                `json:"groups,omitempty"`
+	VLAN              InterfaceVlan           `json:"vlan,omitempty"`
+	LaggProto         string                  `json:"laggproto,omitempty"`
+	LaggHash          string                  `json:"lagghash,omitempty"`
+	LaggOptions       InterfaceLaggOptions    `json:"laggoptions,omitempty"`
+	LaggStatistics    InterfaceLaggStatistics `json:"laggstatistics,omitempty"`
+}
+
+type InterfaceLaggOptions struct {
+	Flags       []string `json:"flags,omitempty"`
+	FlowIDShift string   `json:"flowid_shift,omitempty"`
+}
+
+type InterfaceLaggStatistics struct {
+	ActivePorts string `json:"active ports,omitempty"`
+	Flapping    string `json:"flapping,omitempty"`
 }
 
 type InterfaceND6 struct {

--- a/schema/interfaces.yml
+++ b/schema/interfaces.yml
@@ -240,8 +240,30 @@ rpc:
           key: lagghash
           omitEmpty: true
         - name: LaggOptions
-          type: string
+          type: InterfaceLaggOptions
           key: laggoptions
+          omitEmpty: true
+        - name: LaggStatistics
+          type: InterfaceLaggStatistics
+          key: laggstatistics
+          omitEmpty: true
+      InterfaceLaggOptions:
+        - name: Flags
+          type: '[]string'
+          key: flags
+          omitEmpty: true
+        - name: FlowIDShift
+          type: string
+          key: flowid_shift
+          omitEmpty: true
+      InterfaceLaggStatistics:
+        - name: ActivePorts
+          type: string
+          key: "active ports"
+          omitEmpty: true
+        - name: Flapping
+          type: string
+          key: flapping
           omitEmpty: true
       InterfaceND6:
         - name: Flags


### PR DESCRIPTION
LaggOptions and LaggStastics are missing and should be added.

When using `client.Interfaces().OverviewGet(ctx)` I get the following

`Get call failed: json: cannot unmarshal object into Go struct field InterfaceInfo.rows.laggoptions of type string`

Example output
```json
      "laggoptions": {
        "flags": [
          "lacp_fast_timo"
        ],
        "flowid_shift": "16"
      },
      "laggstatistics": {
        "active ports": "2",
        "flapping": "0"
      },
```

hope this helps