### PR TITLE
feat(firewall): add urljson alias type with path_expression field

### DIFF
--- a/pkg/firewall/alias.go
+++ b/pkg/firewall/alias.go
@@ -20,16 +20,17 @@ var AliasOpts = api.ReqOpts{
 // Data structs
 
 type Alias struct {
-	Enabled     string                `json:"enabled"`
-	Name        string                `json:"name"`
-	Type        api.SelectedMap       `json:"type"`
-	IPProtocol  api.SelectedMapList   `json:"proto"`
-	Interface   api.SelectedMap       `json:"interface"`
-	Content     api.SelectedMapListNL `json:"content"`
-	Categories  api.SelectedMapList   `json:"categories"`
-	UpdateFreq  string                `json:"updatefreq"`
-	Statistics  string                `json:"counters"`
-	Description string                `json:"description"`
+	Enabled        string                `json:"enabled"`
+	Name           string                `json:"name"`
+	Type           api.SelectedMap       `json:"type"`
+	IPProtocol     api.SelectedMapList   `json:"proto"`
+	Interface      api.SelectedMap       `json:"interface"`
+	Content        api.SelectedMapListNL `json:"content"`
+	Categories     api.SelectedMapList   `json:"categories"`
+	UpdateFreq     string                `json:"updatefreq"`
+	PathExpression string                `json:"path_expression"`
+	Statistics     string                `json:"counters"`
+	Description    string                `json:"description"`
 }
 
 // CRUD operations

--- a/pkg/firewall/alias_test.go
+++ b/pkg/firewall/alias_test.go
@@ -8,24 +8,23 @@ import (
 	"github.com/browningluke/opnsense-go/pkg/api"
 )
 
-func TestAlias(t *testing.T) {
-	opnsense_url := os.Getenv("OPNSENSE_URI")
-	opnsense_key := os.Getenv("OPNSENSE_API_KEY")
-	opnsense_secret := os.Getenv("OPNSENSE_API_SECRET")
-
-	api_client := api.NewClient(api.Options{
-		Uri:           opnsense_url,
-		APIKey:        opnsense_key,
-		APISecret:     opnsense_secret,
-		AllowInsecure: true,
-		MaxBackoff:    30,
-		MinBackoff:    1,
-		MaxRetries:    4,
-	})
-
-	controller := Controller{
-		Api: api_client,
+func newController(t *testing.T) Controller {
+	t.Helper()
+	return Controller{
+		Api: api.NewClient(api.Options{
+			Uri:           os.Getenv("OPNSENSE_URI"),
+			APIKey:        os.Getenv("OPNSENSE_API_KEY"),
+			APISecret:     os.Getenv("OPNSENSE_API_SECRET"),
+			AllowInsecure: true,
+			MaxBackoff:    30,
+			MinBackoff:    1,
+			MaxRetries:    4,
+		}),
 	}
+}
+
+func TestAlias(t *testing.T) {
+	controller := newController(t)
 	ctx := context.Background()
 
 	alias := &Alias{
@@ -79,4 +78,57 @@ func TestAlias(t *testing.T) {
 		t.Fatalf("Failed to delete alias: %v", err)
 	}
 	t.Logf("Deleted alias with key: %s", key)
+}
+
+func TestAliasURLJSON(t *testing.T) {
+	controller := newController(t)
+	ctx := context.Background()
+
+	alias := &Alias{
+		Enabled:        "1",
+		Name:           "testurljsonalias",
+		Type:           api.SelectedMap("urljson"),
+		Content:        api.SelectedMapListNL{"https://api.github.com/meta"},
+		PathExpression: ".web + .api + .git | .[]",
+		Description:    "Test urljson alias",
+	}
+
+	key, err := controller.AddAlias(ctx, alias)
+	if err != nil {
+		t.Fatalf("Failed to add urljson alias: %v", err)
+	}
+	t.Logf("Added urljson alias with key: %s", key)
+
+	retrievedAlias, err := controller.GetAlias(ctx, key)
+	if err != nil {
+		t.Fatalf("Failed to get urljson alias: %v", err)
+	}
+	t.Logf("Retrieved urljson alias: %+v", retrievedAlias)
+	if retrievedAlias.Type.String() != "urljson" {
+		t.Fatalf("Retrieved alias type does not match: got %s, want urljson", retrievedAlias.Type.String())
+	}
+	if retrievedAlias.PathExpression != alias.PathExpression {
+		t.Fatalf("Retrieved alias path_expression does not match: got %s, want %s", retrievedAlias.PathExpression, alias.PathExpression)
+	}
+
+	alias.PathExpression = ".web | .[]"
+	alias.Description = "Test urljson alias updated"
+	err = controller.UpdateAlias(ctx, key, alias)
+	if err != nil {
+		t.Fatalf("Failed to update urljson alias: %v", err)
+	}
+
+	retrievedAlias, err = controller.GetAlias(ctx, key)
+	if err != nil {
+		t.Fatalf("Failed to get updated urljson alias: %v", err)
+	}
+	if retrievedAlias.PathExpression != ".web | .[]" {
+		t.Fatalf("Retrieved alias path_expression does not match updated value: got %s, want '.web | .[]'", retrievedAlias.PathExpression)
+	}
+
+	err = controller.DeleteAlias(ctx, key)
+	if err != nil {
+		t.Fatalf("Failed to delete urljson alias: %v", err)
+	}
+	t.Logf("Deleted urljson alias with key: %s", key)
 }

--- a/schema/firewall.yml
+++ b/schema/firewall.yml
@@ -309,6 +309,9 @@ resources:
       - name: UpdateFreq # only when type = urltable
         type: string
         key: updatefreq
+      - name: PathExpression # only when type = urljson
+        type: string
+        key: path_expression
       - name: Statistics # not when type = port
         type: string
         key: counters


### PR DESCRIPTION
## Summary

- Adds `PathExpression` field (`path_expression` JSON key) to the `Alias` struct in `pkg/firewall/alias.go`
- Updates `schema/firewall.yml` to include the new field, regenerating `alias.go` via `make all`
- Adds `TestAliasURLJSON` integration test covering create, read, update, and delete of a `urljson` alias

## Test plan

- [x] Run `go test ./pkg/firewall -run TestAliasURLJSON` against a live OPNsense instance with env vars `OPNSENSE_URI`, `OPNSENSE_API_KEY`, `OPNSENSE_API_SECRET`
- [x] Verify `path_expression` is persisted and retrieved correctly
- [x] Verify update of `path_expression` is reflected on re-read