### PR TITLE
fix(api): return error instead of panicking on unknown reconfigure response

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -180,7 +180,7 @@ func (c *Client) ReconfigureService(ctx context.Context, endpoint string) error 
 	} else if respJson.Result != "" {
 		status = respJson.Result
 	} else {
-		panic(errors.New("reconfigure returned with unknown status response"))
+		return errors.New("reconfigure returned with unknown status response")
 	}
 
 	// Validate service restarted correctly


### PR DESCRIPTION
## Summary

`ReconfigureService` panics with `panic(errors.New(...))` when the reconfigure response payload contains neither a `status` nor a `result` field. As a library, panicking inside an exported function crashes the calling process (e.g. `terraform apply`) instead of producing a normal diagnostic — every other failure path in this function already returns an error, so this aligns the unhandled branch with the rest.

## Changes

- `pkg/api/client.go`: replace `panic(errors.New(...))` with `return errors.New(...)`.

## Test plan

- [ ] `go build ./pkg/...` clean
- [ ] `go vet ./pkg/api/...` clean
- [ ] Existing integration tests against a live OPNsense instance still pass