### PR TITLE
chore(api): remove dead counter in GetAll

### DIFF
--- a/pkg/api/crud_utils.go
+++ b/pkg/api/crud_utils.go
@@ -127,15 +127,13 @@ func GetAll[K any](c *Client, ctx context.Context, opts ReqOpts, resources []K) 
 	}
 
 	// Find key in returned list
-	i := 0
-	for key, _ := range reqData {
+	for key := range reqData {
 		r := new(K)
 		if err := json.Unmarshal(reqData[key], r); err != nil {
 			return nil, err
 		}
 
 		resources = append(resources, *r)
-		i++
 	}
 
 	if len(resources) == 0 {


### PR DESCRIPTION
## Summary

`GetAll` in `pkg/api/crud_utils.go` declared an `i := 0` counter and incremented it inside the loop, but the value was never read. Dropping it and tightening the `for key, _ := range` to `for key := range` for `gosimple` S1005.

## Changes

- `pkg/api/crud_utils.go`: remove unused `i` counter; replace `for key, _ := range` with `for key := range`.

## Test plan

- [ ] `go build ./pkg/...` clean
- [ ] `go vet ./pkg/api/...` clean
- [ ] No behavioural change — pure cleanup