### PR TITLE
fix(api): return NotFound when monad key absent in response

### DIFF
--- a/pkg/api/crud_utils.go
+++ b/pkg/api/crud_utils.go
@@ -14,7 +14,12 @@ func resourceWrap[K any](monad string, resource K) map[string]K {
 }
 
 func resourceUnwrap[K any](monad string, resource K, reqData map[string]json.RawMessage) error {
-	wrapped := reqData[monad]
+	wrapped, ok := reqData[monad]
+	if !ok || len(wrapped) == 0 {
+		// Upstream returned 200 but the response did not include the
+		// configured monad — treat as not-found.
+		return errs.NewNotFoundError()
+	}
 
 	if err := json.Unmarshal(wrapped, resource); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Get-style endpoints occasionally return HTTP 200 with a body that does not contain the configured monad key — for example, an empty JSON object when an upstream ID has been deleted. `resourceUnwrap` would then read the nil `json.RawMessage` and forward `json.Unmarshal`'s error (`unexpected end of JSON input`) to the caller.

That has two problems:
1. The error leaks an implementation detail; callers see a cryptic JSON message.
2. `errors.As(err, &errs.NotFoundError)` does not match it, so callers' existing not-found branches (e.g. "resource not present in remote, removing from state" in the terraform-provider) silently miss this case.

Detect the missing/empty wrapped value up front and return `errs.NewNotFoundError()`.

## Changes

- `pkg/api/crud_utils.go`: check `wrapped, ok := reqData[monad]`; return `errs.NewNotFoundError()` when `!ok || len(wrapped) == 0`.

## Test plan

- [ ] `go build ./pkg/...` clean
- [ ] `go vet ./pkg/api/...` clean
- [ ] Existing integration tests still pass
- [ ] Callers in terraform-provider-opnsense that rely on `errors.As(err, &errs.NotFoundError)` now also catch this case