### PR TITLE
fix(api): copy slice before sorting in SelectedMapList.MarshalJSON

### DIFF
--- a/pkg/api/selected_map_list.go
+++ b/pkg/api/selected_map_list.go
@@ -43,10 +43,11 @@ func (s *SelectedMapList) UnmarshalJSON(data []byte) error {
 }
 
 func (s *SelectedMapList) MarshalJSON() ([]byte, error) {
-	// Ensure list is sorted
-	sort.Strings(*s)
-	str := strings.Join(*s, ",")
-	return json.Marshal(str)
+	// Sort a copy so Marshal stays read-only; the receiver may be
+	// shared with concurrent readers.
+	sorted := append([]string(nil), (*s)...)
+	sort.Strings(sorted)
+	return json.Marshal(strings.Join(sorted, ","))
 }
 
 func (s *SelectedMapList) String() string {
@@ -70,10 +71,10 @@ func (s *SelectedMapListNL) UnmarshalJSON(data []byte) error {
 }
 
 func (s *SelectedMapListNL) MarshalJSON() ([]byte, error) {
-	// Ensure list is sorted
-	sort.Strings(*s)
-	str := strings.Join(*s, "\n")
-	return json.Marshal(str)
+	// Sort a copy so Marshal stays read-only; see SelectedMapList.MarshalJSON.
+	sorted := append([]string(nil), (*s)...)
+	sort.Strings(sorted)
+	return json.Marshal(strings.Join(sorted, "\n"))
 }
 
 func (s *SelectedMapListNL) String() string {


### PR DESCRIPTION
## Summary

`SelectedMapList.MarshalJSON` and `SelectedMapListNL.MarshalJSON` both called `sort.Strings(*s)` directly on the receiver. `json.Marshal` is conventionally a read-only operation; mutating the underlying slice means

1. Any goroutine iterating the same `SelectedMapList` while another marshals it races with the sort.
2. The in-memory order observed by other code changes after a marshal — a surprising side effect for what looks like a serialisation call.

Sort a defensive copy and `strings.Join` from that instead.

## Changes

- `pkg/api/selected_map_list.go`: both `MarshalJSON` methods now `append([]string(nil), (*s)...)` then sort the copy.

## Test plan

- [x] `go build ./pkg/...` clean
- [x] `go test ./pkg/api/...` passes (existing unit tests cover unmarshal; marshal output unchanged for any caller because the sorted *contents* are the same)
- [ ] Race detector clean — could not exercise the previous race without writing a dedicated test; happy to add one if you'd like