### PR TITLE
fix(generate): skip non-YAML entries in schema directory

### DIFF
--- a/internal/generate/schema/schema.go
+++ b/internal/generate/schema/schema.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -138,10 +139,21 @@ func GetControllerNames() []string {
 
 	var controllerNames []string
 	for _, file := range files {
+		// Skip directories and non-YAML entries (.DS_Store, README.md,
+		// editor swap files, etc.). Without this guard, a single stray
+		// file in schema/ makes the generator panic with an opaque
+		// yaml.Unmarshal error.
+		if file.IsDir() {
+			continue
+		}
+		name := file.Name()
+		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
 		controllerNames = append(
 			controllerNames,
 			// Get load controller name from schema file
-			newController(fmt.Sprintf("%s/%s", relativePathToSchema, file.Name())).Name,
+			newController(fmt.Sprintf("%s/%s", relativePathToSchema, name)).Name,
 		)
 	}
 	return controllerNames


### PR DESCRIPTION
## Summary

`GetControllerNames` in the code generator iterates every file returned by `os.ReadDir(schema/)` and feeds it to `newController`, which calls `yaml.Unmarshal` and panics on any error. A single stray file in `schema/` — `.DS_Store` on macOS, a `README.md`, an editor swap file — breaks `go generate` / `make all` with an opaque YAML error.

Skip directories and dir entries whose name does not end in `.yml` / `.yaml` before calling `newController`.

## Changes

- `internal/generate/schema/schema.go`: filter to regular YAML files in `GetControllerNames`.

## Test plan

- [x] `go build ./internal/...` clean
- [x] `go vet ./internal/generate/...` clean
- [ ] `make all` produces no diff on a clean tree (extension filter accepts all current `.yml` schemas)