### PR TITLE
fix(generate): emit empty reconfigure endpoint when controller has none

### DIFF
--- a/internal/generate/api/templates/resource.tmpl
+++ b/internal/generate/api/templates/resource.tmpl
@@ -18,8 +18,10 @@ var {{ .Resource.Name }}Opts = api.ReqOpts{
     "",
     {{- else if not (eq .Resource.Endpoints.Reconfigure "") -}}
     "{{ .Resource.Endpoints.Reconfigure }}",
-    {{- else -}}
+    {{- else if not (eq .Controller.ReconfigureEndpoint "") -}}
     {{ .Controller.Name }}ReconfigureEndpoint,
+    {{- else -}}
+    "",
     {{- end }}
 	Monad:               "{{ .Resource.Monad }}",
 }


### PR DESCRIPTION
## Summary

The resource template falls back to `{{ .Controller.Name }}ReconfigureEndpoint` when a resource has neither `reconfigure: "null"`, `readOnly: true`, nor its own `endpoints.reconfigure`. But `controller.tmpl` only emits that `const` when the controller's top-level `reconfigureEndpoint` is non-empty, so a schema that combined an empty controller-wide reconfigure with a resource that omits its own reconfigure would generate Go that references an undeclared constant.

Add an explicit `""` fallback when both the resource-level and controller-level endpoints are empty.

## Changes

- `internal/generate/api/templates/resource.tmpl`: add an `else if not (eq .Controller.ReconfigureEndpoint "")` branch before the existing controller-const branch.

## Test plan

- [x] `make all` regenerates the world; `git diff` on generated files is empty (every existing schema hits one of the prior branches, confirming this is purely defensive).
- [x] `go build ./...` clean.
- This removes a foot-gun the next time someone adds a service whose reconfigure semantics live entirely on per-resource endpoints with no controller-wide fallback.