### PR TITLE
test: skip integration tests when OPNSENSE_URI/KEY/SECRET unset

### DIFF
--- a/pkg/auth/main_test.go
+++ b/pkg/auth/main_test.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/auth")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/dnsmasq/main_test.go
+++ b/pkg/dnsmasq/main_test.go
@@ -1,0 +1,18 @@
+package dnsmasq
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/dnsmasq")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/firewall/main_test.go
+++ b/pkg/firewall/main_test.go
@@ -1,0 +1,18 @@
+package firewall
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/firewall")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/interfaces/main_test.go
+++ b/pkg/interfaces/main_test.go
@@ -1,0 +1,18 @@
+package interfaces
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/interfaces")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/ipsec/main_test.go
+++ b/pkg/ipsec/main_test.go
@@ -1,0 +1,18 @@
+package ipsec
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/ipsec")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/kea/main_test.go
+++ b/pkg/kea/main_test.go
@@ -1,0 +1,18 @@
+package kea
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/kea")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/unbound/main_test.go
+++ b/pkg/unbound/main_test.go
@@ -1,0 +1,18 @@
+package unbound
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// Integration tests in this package require a live OPNsense instance. Skip
+// cleanly when the required env vars are unset so `go test ./...` doesn't
+// fail with cryptic network errors on a developer's first checkout.
+func TestMain(m *testing.M) {
+	if os.Getenv("OPNSENSE_URI") == "" || os.Getenv("OPNSENSE_API_KEY") == "" || os.Getenv("OPNSENSE_API_SECRET") == "" {
+		fmt.Fprintln(os.Stderr, "OPNSENSE_URI/OPNSENSE_API_KEY/OPNSENSE_API_SECRET not set; skipping integration tests in pkg/unbound")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

Every test under `pkg/auth`, `pkg/dnsmasq`, `pkg/firewall`, `pkg/interfaces`, `pkg/ipsec`, `pkg/kea` and `pkg/unbound` is an integration test that requires a live OPNsense. Without the env vars set, running `go test ./...` on a fresh checkout fails with cryptic network errors as the client dials an empty URI — so contributors get noise instead of a clear "skipped" signal.

Add a `TestMain` in each integration-only package that exits cleanly (after printing a notice to stderr) when any of `OPNSENSE_URI`, `OPNSENSE_API_KEY`, or `OPNSENSE_API_SECRET` is unset. `pkg/api` holds pure unit tests and is intentionally left alone.

## Changes

- New file in each of: `pkg/auth/main_test.go`, `pkg/dnsmasq/main_test.go`, `pkg/firewall/main_test.go`, `pkg/interfaces/main_test.go`, `pkg/ipsec/main_test.go`, `pkg/kea/main_test.go`, `pkg/unbound/main_test.go`.

## Test plan

- [x] `env -u OPNSENSE_URI -u OPNSENSE_API_KEY -u OPNSENSE_API_SECRET go test ./pkg/...` passes (integration packages report `ok` with no tests run; `pkg/api` still runs real unit tests).
- [ ] With env set against a live VM, integration tests run as before.