### PR TITLE
fix(api): honour context cancellation in MutexKV.Lock

### DIFF
--- a/pkg/api/crud_utils.go
+++ b/pkg/api/crud_utils.go
@@ -26,7 +26,9 @@ func resourceUnwrap[K any](monad string, resource K, reqData map[string]json.Raw
 func set[K any](c *Client, ctx context.Context, opts ReqOpts, resource *K, endpoint string) (string, error) {
 	// Since the OPNsense controller has to be reconfigured after every change, locking the mutex prevents
 	// the API from being written to while it's reconfiguring, which results in data loss.
-	GlobalMutexKV.Lock(clientMutexKey, ctx)
+	if err := GlobalMutexKV.Lock(clientMutexKey, ctx); err != nil {
+		return "", err
+	}
 	defer GlobalMutexKV.Unlock(clientMutexKey, ctx)
 
 	// Wrap resource
@@ -147,7 +149,9 @@ func GetAll[K any](c *Client, ctx context.Context, opts ReqOpts, resources []K) 
 func Delete(c *Client, ctx context.Context, opts ReqOpts, id string) error {
 	// Since the OPNsense controller has to be reconfigured after every change, locking the mutex prevents
 	// the API from being written to while it's reconfiguring, which results in data loss.
-	GlobalMutexKV.Lock(clientMutexKey, ctx)
+	if err := GlobalMutexKV.Lock(clientMutexKey, ctx); err != nil {
+		return err
+	}
 	defer GlobalMutexKV.Unlock(clientMutexKey, ctx)
 
 	respJson := &deleteResp{}

--- a/pkg/api/mutexkv.go
+++ b/pkg/api/mutexkv.go
@@ -20,13 +20,37 @@ type mutexKV struct {
 	store map[string]*sync.Mutex
 }
 
-// Locks the mutex for the given key. Caller is responsible for calling Unlock
-// for the same key
-func (m *mutexKV) Lock(key string, ctx context.Context) {
-	m.Get(key).Lock()
+// Lock acquires the mutex for the given key, honouring ctx cancellation.
+// On success the caller is responsible for calling Unlock for the same key.
+// If ctx is cancelled before the lock can be acquired, ctx.Err() is returned
+// and the caller must NOT call Unlock — the acquisition is abandoned and the
+// inner mutex is released as soon as it can be taken.
+func (m *mutexKV) Lock(key string, ctx context.Context) error {
+	mu := m.Get(key)
+
+	acquired := make(chan struct{})
+	go func() {
+		mu.Lock()
+		// If the outer select has already returned via ctx.Done(), nothing
+		// is reading from acquired. Release the lock immediately so it
+		// isn't held forever.
+		select {
+		case acquired <- struct{}{}:
+		default:
+			mu.Unlock()
+		}
+	}()
+
+	select {
+	case <-acquired:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
-// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+// Unlock releases the mutex for the given key. The caller must have
+// previously held the lock (a successful Lock for the same key).
 func (m *mutexKV) Unlock(key string, ctx context.Context) {
 	m.Get(key).Unlock()
 }


### PR DESCRIPTION
## Summary

`mutexKV.Lock(key, ctx)` accepted a `context.Context` but the implementation was a plain `sync.Mutex.Lock()` that could not be interrupted. A caller whose context is cancelled while another goroutine holds the global mutex through a 30-second reconfigure had no way to abort, defeating the purpose of context propagation.

Convert `Lock` to return an `error`: spawn a goroutine to acquire the inner mutex and race it against `ctx.Done()`. If the outer select picks `ctx.Done()` first, the goroutine still completes its `Lock()` and immediately unlocks (`default` case on the channel send), so the lock isn't leaked.

Callers (`set`, `Delete`) now early-return when `Lock` fails — they already propagate context cancellation everywhere else in the request path. The error path never reaches the `defer Unlock`, which is correct because Unlock would panic on an un-acquired mutex.

## Changes

- `pkg/api/mutexkv.go`: `Lock` returns `error`; race acquisition against ctx; release inner mutex on cancellation.
- `pkg/api/crud_utils.go`: `set` and `Delete` propagate the error from `Lock`.

## Breaking API change?

`mutexKV` is unexported, but `GlobalMutexKV` is exported. The signature of `Lock` changes from `(key, ctx) -> ()` to `(key, ctx) -> error`. No external callers were found in `opnsense-go` itself or in `terraform-provider-opnsense`; the API is internal infrastructure. Targeting `main` accordingly.

## Test plan

- [x] `go build ./pkg/...` clean
- [x] `go vet ./pkg/...` clean
- [x] `go test ./pkg/api/...` passes
- [ ] Integration tests against a live VM with deliberately-cancelled contexts (manual)