### PR TITLE
feat(generate): support `queryParameter` on RPC params

### DIFF
--- a/internal/generate/api/templates/rpc.tmpl
+++ b/internal/generate/api/templates/rpc.tmpl
@@ -38,19 +38,28 @@ func (c *Controller) {{ $rpcContext.Name }}{{ .Name }}(ctx context.Context
     ) (*{{ .ResultType }},error) {
 
     callParams := []string{}
+    queryParams := make(map[string]string)
     bodyParams := make(map[string]interface{})
 
     {{ range .Parameters }}
-        {{- if and (not .IsBodyParameter) (not .CustomType) }}
+        {{- if .IsQueryParameter }}
+            {{- if .Optional }}
+            if {{ .Name }} != nil {
+            queryParams["{{ .KeyOrName }}"]=*{{ .Name }}
+            }
+            {{- else }}
+            queryParams["{{ .KeyOrName }}"]={{ .Name }}
+            {{- end }}
+        {{- else if and (not .IsBodyParameter) (not .CustomType) }}
             {{- if .Optional }}
             if {{ .Name }} != nil {
             callParams = append(callParams,*{{ .Name }})
             }
             {{- else }}
-            callParams = append(callParams,{{ .Name }}) 
+            callParams = append(callParams,{{ .Name }})
             {{- end }}
         {{- else }}
-            bodyParams["{{ .Name }}"]={{ .Name }}
+            bodyParams["{{ .KeyOrName }}"]={{ .Name }}
         {{- end }}
     {{ end }}
 
@@ -58,6 +67,7 @@ func (c *Controller) {{ $rpcContext.Name }}{{ .Name }}(ctx context.Context
         BaseEndpoint: "{{ .Endpoint }}",
         Method: "{{ .Method }}",
         PathParameters: callParams,
+        QueryParameters: queryParams,
         BodyParameters: bodyParams,
     }
     

--- a/internal/generate/schema/schema.go
+++ b/internal/generate/schema/schema.go
@@ -74,10 +74,22 @@ type RPCData struct {
 }
 
 type Parameter struct {
-	Name            string `yaml:"name"`
-	Optional        bool   `yaml:"optional"`
-	IsBodyParameter bool   `yaml:"bodyParameter"`
-	CustomType      string `yaml:"customType"`
+	Name             string `yaml:"name"`
+	Key              string `yaml:"key"`
+	Optional         bool   `yaml:"optional"`
+	IsBodyParameter  bool   `yaml:"bodyParameter"`
+	IsQueryParameter bool   `yaml:"queryParameter"`
+	CustomType       string `yaml:"customType"`
+}
+
+// KeyOrName returns the wire/URL key the API expects for this parameter.
+// Defaults to Name when Key is unset; lets schemas use a Go-safe variable
+// name (e.g. keyType) while emitting the actual API key (e.g. ?type=).
+func (p *Parameter) KeyOrName() string {
+	if p.Key != "" {
+		return p.Key
+	}
+	return p.Name
 }
 
 type RPCCallData struct {

--- a/pkg/api/data.go
+++ b/pkg/api/data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 )
 
@@ -30,10 +31,11 @@ type deleteResp struct {
 
 // RCP Options
 type RPCOpts struct {
-	BaseEndpoint   string
-	Method         string
-	PathParameters []string
-	BodyParameters map[string]interface{}
+	BaseEndpoint    string
+	Method          string
+	PathParameters  []string
+	QueryParameters map[string]string
+	BodyParameters  map[string]interface{}
 }
 
 func (p *RPCOpts) EndpointURL() string {
@@ -48,6 +50,27 @@ func (p *RPCOpts) EndpointURL() string {
 		} else {
 			currentPath += "/" + escapedParam
 		}
+	}
+
+	if len(p.QueryParameters) > 0 {
+		keys := make([]string, 0, len(p.QueryParameters))
+		for k := range p.QueryParameters {
+			keys = append(keys, k)
+		}
+		// Sort so the URL is deterministic — important for any test that
+		// asserts on the request URL and for caches/loggers that key on it.
+		sort.Strings(keys)
+
+		values := url.Values{}
+		for _, k := range keys {
+			values.Set(k, p.QueryParameters[k])
+		}
+
+		separator := "?"
+		if strings.Contains(currentPath, "?") {
+			separator = "&"
+		}
+		currentPath += separator + values.Encode()
 	}
 	return currentPath
 }

--- a/pkg/api/data_test.go
+++ b/pkg/api/data_test.go
@@ -1,0 +1,85 @@
+package api
+
+import "testing"
+
+func TestRPCOpts_EndpointURL(t *testing.T) {
+	tests := []struct {
+		name string
+		opts RPCOpts
+		want string
+	}{
+		{
+			name: "no params",
+			opts: RPCOpts{BaseEndpoint: "/foo/bar"},
+			want: "/foo/bar",
+		},
+		{
+			name: "path params only",
+			opts: RPCOpts{
+				BaseEndpoint:   "/foo/bar",
+				PathParameters: []string{"abc"},
+			},
+			want: "/foo/bar/abc",
+		},
+		{
+			name: "query params only",
+			opts: RPCOpts{
+				BaseEndpoint:    "/foo/bar",
+				QueryParameters: map[string]string{"type": "tls-auth"},
+			},
+			want: "/foo/bar?type=tls-auth",
+		},
+		{
+			name: "path and query params",
+			opts: RPCOpts{
+				BaseEndpoint:    "/foo/bar",
+				PathParameters:  []string{"abc"},
+				QueryParameters: map[string]string{"flag": "1"},
+			},
+			want: "/foo/bar/abc?flag=1",
+		},
+		{
+			name: "multiple query params are sorted",
+			opts: RPCOpts{
+				BaseEndpoint: "/foo/bar",
+				QueryParameters: map[string]string{
+					"z": "last",
+					"a": "first",
+				},
+			},
+			want: "/foo/bar?a=first&z=last",
+		},
+		{
+			name: "values are url-escaped",
+			opts: RPCOpts{
+				BaseEndpoint:    "/foo/bar",
+				QueryParameters: map[string]string{"q": "a b&c"},
+			},
+			want: "/foo/bar?q=a+b%26c",
+		},
+		{
+			name: "existing query string is preserved with &",
+			opts: RPCOpts{
+				BaseEndpoint:    "/foo/bar?existing=1",
+				QueryParameters: map[string]string{"added": "2"},
+			},
+			want: "/foo/bar?existing=1&added=2",
+		},
+		{
+			name: "empty query map adds no separator",
+			opts: RPCOpts{
+				BaseEndpoint:    "/foo/bar",
+				QueryParameters: map[string]string{},
+			},
+			want: "/foo/bar",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.opts.EndpointURL(); got != tc.want {
+				t.Fatalf("EndpointURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/privilege.go
+++ b/pkg/auth/privilege.go
@@ -34,15 +34,17 @@ type PrivilegeSetItemWrapper struct {
 func (c *Controller) PrivilegeGetItem(ctx context.Context, id string) (*PrivilegeGetItemWrapper, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/priv/get_item",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/priv/get_item",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &PrivilegeGetItemWrapper{}
@@ -57,6 +59,7 @@ func (c *Controller) PrivilegeGetItem(ctx context.Context, id string) (*Privileg
 func (c *Controller) PrivilegeSetItem(ctx context.Context, id string, priv *PrivilegeSetItem) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
@@ -64,10 +67,11 @@ func (c *Controller) PrivilegeSetItem(ctx context.Context, id string, priv *Priv
 	bodyParams["priv"] = priv
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/priv/set_item",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/priv/set_item",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}

--- a/pkg/auth/privilege_search.go
+++ b/pkg/auth/privilege_search.go
@@ -30,13 +30,15 @@ type PrivilegeGetAllResult struct {
 func (c *Controller) PrivilegeGetAll(ctx context.Context) (*PrivilegeGetAllResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/priv/search",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/priv/search",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &PrivilegeGetAllResult{}

--- a/pkg/auth/user_api_key.go
+++ b/pkg/auth/user_api_key.go
@@ -35,15 +35,17 @@ type GetAllApiKeysResult struct {
 func (c *Controller) UserAddApiKey(ctx context.Context, username string) (*AddApiKeyResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, username)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/user/add_api_key",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/user/add_api_key",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &AddApiKeyResult{}
@@ -58,15 +60,17 @@ func (c *Controller) UserAddApiKey(ctx context.Context, username string) (*AddAp
 func (c *Controller) UserDeleteApiKey(ctx context.Context, id string) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/user/del_api_key",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/user/del_api_key",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}
@@ -81,13 +85,15 @@ func (c *Controller) UserDeleteApiKey(ctx context.Context, id string) (*api.Acti
 func (c *Controller) UserGetAllApiKeys(ctx context.Context) (*GetAllApiKeysResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/user/search_api_key",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/user/search_api_key",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &GetAllApiKeysResult{}

--- a/pkg/auth/user_otp.go
+++ b/pkg/auth/user_otp.go
@@ -20,13 +20,15 @@ type NewOtpSeedResult struct {
 func (c *Controller) UserNewOtpSeed(ctx context.Context) (*NewOtpSeedResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/auth/user/new_otp_seed",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/auth/user/new_otp_seed",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &NewOtpSeedResult{}

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -34,13 +34,15 @@ type ServiceItem struct {
 func (c *Controller) ServiceSearch(ctx context.Context) (*SearchServicesResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/service/search",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/service/search",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchServicesResponse{}
@@ -55,15 +57,17 @@ func (c *Controller) ServiceSearch(ctx context.Context) (*SearchServicesResponse
 func (c *Controller) ServiceStart(ctx context.Context, id string) (*ServiceActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/service/start",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/service/start",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ServiceActionResult{}
@@ -78,15 +82,17 @@ func (c *Controller) ServiceStart(ctx context.Context, id string) (*ServiceActio
 func (c *Controller) ServiceStop(ctx context.Context, id string) (*ServiceActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/service/stop",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/service/stop",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ServiceActionResult{}
@@ -101,15 +107,17 @@ func (c *Controller) ServiceStop(ctx context.Context, id string) (*ServiceAction
 func (c *Controller) ServiceRestart(ctx context.Context, id string) (*ServiceActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callParams = append(callParams, id)
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/service/restart",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/service/restart",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ServiceActionResult{}

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -29,13 +29,15 @@ type SystemStatus struct {
 func (c *Controller) SystemHalt(ctx context.Context) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/system/halt",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/system/halt",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}
@@ -50,13 +52,15 @@ func (c *Controller) SystemHalt(ctx context.Context) (*api.ActionResult, error) 
 func (c *Controller) SystemReboot(ctx context.Context) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/system/reboot",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/system/reboot",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}
@@ -71,13 +75,15 @@ func (c *Controller) SystemReboot(ctx context.Context) (*api.ActionResult, error
 func (c *Controller) SystemStatus(ctx context.Context) (*SystemStatus, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/system/status",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/system/status",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SystemStatus{}
@@ -92,15 +98,17 @@ func (c *Controller) SystemStatus(ctx context.Context) (*SystemStatus, error) {
 func (c *Controller) SystemDismissStatus(ctx context.Context, subject string) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["subject"] = subject
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/core/system/dismiss_status",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/core/system/dismiss_status",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}

--- a/pkg/dnsmasq/general.go
+++ b/pkg/dnsmasq/general.go
@@ -57,13 +57,15 @@ type GeneralSettingsWrapper struct {
 func (c *Controller) GeneralSettingsGet(ctx context.Context) (*GeneralSettingsWrapper, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/get",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/get",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &GeneralSettingsWrapper{}
@@ -78,15 +80,17 @@ func (c *Controller) GeneralSettingsGet(ctx context.Context) (*GeneralSettingsWr
 func (c *Controller) GeneralSettingsSet(ctx context.Context, dnsmasq *GeneralSettings) (*api.ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["dnsmasq"] = dnsmasq
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/set",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/set",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ActionResult{}

--- a/pkg/dnsmasq/search.go
+++ b/pkg/dnsmasq/search.go
@@ -147,15 +147,17 @@ type SearchTagResponse struct {
 func (c *Controller) SearchHost(ctx context.Context, rowCount string) (*SearchHostResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_host",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_host",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchHostResponse{}
@@ -170,15 +172,17 @@ func (c *Controller) SearchHost(ctx context.Context, rowCount string) (*SearchHo
 func (c *Controller) SearchDomain(ctx context.Context, rowCount string) (*SearchDomainResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_domain",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_domain",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchDomainResponse{}
@@ -193,15 +197,17 @@ func (c *Controller) SearchDomain(ctx context.Context, rowCount string) (*Search
 func (c *Controller) SearchRange(ctx context.Context, rowCount string) (*SearchRangeResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_range",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_range",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchRangeResponse{}
@@ -216,15 +222,17 @@ func (c *Controller) SearchRange(ctx context.Context, rowCount string) (*SearchR
 func (c *Controller) SearchOption(ctx context.Context, rowCount string) (*SearchOptionResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_option",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_option",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchOptionResponse{}
@@ -239,15 +247,17 @@ func (c *Controller) SearchOption(ctx context.Context, rowCount string) (*Search
 func (c *Controller) SearchBoot(ctx context.Context, rowCount string) (*SearchBootResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_boot",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_boot",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchBootResponse{}
@@ -262,15 +272,17 @@ func (c *Controller) SearchBoot(ctx context.Context, rowCount string) (*SearchBo
 func (c *Controller) SearchTag(ctx context.Context, rowCount string) (*SearchTagResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["rowCount"] = rowCount
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/settings/search_tag",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/settings/search_tag",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SearchTagResponse{}

--- a/pkg/dnsmasq/service.go
+++ b/pkg/dnsmasq/service.go
@@ -15,13 +15,15 @@ import (
 func (c *Controller) ServiceReconfigure(ctx context.Context) (*api.ReconfigureStatusResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dnsmasq/service/reconfigure",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dnsmasq/service/reconfigure",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ReconfigureStatusResult{}

--- a/pkg/dyndns/service.go
+++ b/pkg/dyndns/service.go
@@ -15,13 +15,15 @@ import (
 func (c *Controller) ServiceReconfigure(ctx context.Context) (*api.ReconfigureStatusResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/dyndns/service/reconfigure",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/dyndns/service/reconfigure",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &api.ReconfigureStatusResult{}

--- a/pkg/interfaces/overview.go
+++ b/pkg/interfaces/overview.go
@@ -252,13 +252,15 @@ type InterfacesInfoResponse struct {
 func (c *Controller) OverviewGet(ctx context.Context) (*InterfacesInfoResponse, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/interfaces/overview/interfaces_info",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/interfaces/overview/interfaces_info",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &InterfacesInfoResponse{}

--- a/pkg/kea/settings.go
+++ b/pkg/kea/settings.go
@@ -77,13 +77,15 @@ type Result struct {
 func (c *Controller) SettingsDHCPv4Get(ctx context.Context) (*DHCPv4Monad, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/kea/dhcpv4/get",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/kea/dhcpv4/get",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &DHCPv4Monad{}
@@ -98,15 +100,17 @@ func (c *Controller) SettingsDHCPv4Get(ctx context.Context) (*DHCPv4Monad, error
 func (c *Controller) SettingsDHCPv4Update(ctx context.Context, dhcpv4 *DHCPv4Settings) (*Result, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["dhcpv4"] = dhcpv4
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/kea/dhcpv4/set",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/kea/dhcpv4/set",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &Result{}
@@ -121,13 +125,15 @@ func (c *Controller) SettingsDHCPv4Update(ctx context.Context, dhcpv4 *DHCPv4Set
 func (c *Controller) SettingsDHCPv6Get(ctx context.Context) (*DHCPv6Monad, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/kea/dhcpv6/get",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/kea/dhcpv6/get",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &DHCPv6Monad{}
@@ -142,15 +148,17 @@ func (c *Controller) SettingsDHCPv6Get(ctx context.Context) (*DHCPv6Monad, error
 func (c *Controller) SettingsDHCPv6Update(ctx context.Context, dhcpv6 *DHCPv6Settings) (*Result, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["dhcpv6"] = dhcpv6
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/kea/dhcpv6/set",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/kea/dhcpv6/set",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &Result{}
@@ -165,13 +173,15 @@ func (c *Controller) SettingsDHCPv6Update(ctx context.Context, dhcpv6 *DHCPv6Set
 func (c *Controller) SettingsReconfigure(ctx context.Context) (*ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/kea/service/reconfigure",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/kea/service/reconfigure",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ActionResult{}

--- a/pkg/unbound/settings.go
+++ b/pkg/unbound/settings.go
@@ -117,13 +117,15 @@ type SettingsMonad struct {
 func (c *Controller) SettingsGet(ctx context.Context) (*SettingsMonad, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/unbound/settings/get",
-		Method:         "GET",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/unbound/settings/get",
+		Method:          "GET",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &SettingsMonad{}
@@ -138,15 +140,17 @@ func (c *Controller) SettingsGet(ctx context.Context) (*SettingsMonad, error) {
 func (c *Controller) SettingsUpdate(ctx context.Context, unbound *Settings) (*Result, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	bodyParams["unbound"] = unbound
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/unbound/settings/set",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/unbound/settings/set",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &Result{}
@@ -161,13 +165,15 @@ func (c *Controller) SettingsUpdate(ctx context.Context, unbound *Settings) (*Re
 func (c *Controller) SettingsReconfigure(ctx context.Context) (*ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/unbound/service/reconfigure",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/unbound/service/reconfigure",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ActionResult{}
@@ -182,13 +188,15 @@ func (c *Controller) SettingsReconfigure(ctx context.Context) (*ActionResult, er
 func (c *Controller) SettingsReconfigureGeneral(ctx context.Context) (*ActionResult, error) {
 
 	callParams := []string{}
+	queryParams := make(map[string]string)
 	bodyParams := make(map[string]interface{})
 
 	callOpts := api.RPCOpts{
-		BaseEndpoint:   "/unbound/service/reconfigure_general",
-		Method:         "POST",
-		PathParameters: callParams,
-		BodyParameters: bodyParams,
+		BaseEndpoint:    "/unbound/service/reconfigure_general",
+		Method:          "POST",
+		PathParameters:  callParams,
+		QueryParameters: queryParams,
+		BodyParameters:  bodyParams,
 	}
 
 	resultData := &ActionResult{}


### PR DESCRIPTION
## Summary
Lets RPC schemas mark a parameter as a URL query string rather than a path
segment. Some OPNsense routes only accept hyphenated/non-default values via
\`?name=value\` (e.g. \`/openvpn/instances/gen_key?type=tls-auth\` — the
path-parameter form the existing generator emits only works for the default
route value).

Changes:
- \`Parameter\` schema gains an \`IsQueryParameter\` field (\`queryParameter: true\` in YAML).
- \`api.RPCOpts\` gains a \`QueryParameters map[string]string\`.
- \`EndpointURL()\` appends query params with deterministic key ordering and \`url.Values\` escaping; preserves any pre-existing query string on \`BaseEndpoint\` by using \`&\`.
- \`rpc.tmpl\` emits a \`queryParams\` map and routes params with \`queryParameter: true\` into it.

Existing schemas regenerate to declare an empty \`queryParams\` and pass it through. No behaviour change for current callers — \`go test ./...\` and \`make all\` both clean.

## Test plan
- [x] New unit tests in \`pkg/api/data_test.go\` cover the URL builder: no params, path-only, query-only, path+query, multi-key sorting, escaping, existing query string, and the empty-map case.
- [x] \`go build ./pkg/...\` and \`go vet ./...\` clean after regeneration.