### PR TITLE
fix(api): close race in MutexKV.Lock that could hang acquisition

### DIFF
--- a/pkg/api/mutexkv.go
+++ b/pkg/api/mutexkv.go
@@ -29,14 +29,12 @@ func (m *mutexKV) Lock(key string, ctx context.Context) error {
 	mu := m.Get(key)
 
 	acquired := make(chan struct{})
+	abandoned := make(chan struct{})
 	go func() {
 		mu.Lock()
-		// If the outer select has already returned via ctx.Done(), nothing
-		// is reading from acquired. Release the lock immediately so it
-		// isn't held forever.
 		select {
 		case acquired <- struct{}{}:
-		default:
+		case <-abandoned:
 			mu.Unlock()
 		}
 	}()
@@ -45,6 +43,7 @@ func (m *mutexKV) Lock(key string, ctx context.Context) error {
 	case <-acquired:
 		return nil
 	case <-ctx.Done():
+		close(abandoned)
 		return ctx.Err()
 	}
 }

--- a/pkg/api/mutexkv_test.go
+++ b/pkg/api/mutexkv_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMutexKV_LockUncontendedDoesNotHang(t *testing.T) {
+	m := newMutexKV()
+
+	for i := 0; i < 50000; i++ {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if err := m.Lock("k", context.Background()); err != nil {
+				t.Errorf("Lock returned error: %v", err)
+				return
+			}
+			m.Unlock("k", context.Background())
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Lock hung on iteration %d", i)
+		}
+	}
+}
+
+func TestMutexKV_LockHonoursContextCancellation(t *testing.T) {
+	m := newMutexKV()
+
+	if err := m.Lock("k", context.Background()); err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	defer m.Unlock("k", context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := m.Lock("k", ctx)
+	if err == nil {
+		m.Unlock("k", ctx)
+		t.Fatal("expected Lock to return ctx.Err(), got nil")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Lock took too long to honour cancellation: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

`mutexKV.Lock(key, ctx)` (introduced in #70) spawned a goroutine to take the inner `sync.Mutex` so the outer could honour ctx cancellation:

```go
acquired := make(chan struct{})
go func() {
    mu.Lock()
    select {
    case acquired <- struct{}{}:
    default:           // <-- the bug
        mu.Unlock()
    }
}()
select {
case <-acquired:
    return nil
case <-ctx.Done():
    return ctx.Err()
}
```

The `default:` was meant to release the inner mutex if the outer had already returned via `ctx.Done()`. But the timing it actually catches is the opposite: if the inner goroutine reaches its select **before** the outer parks on `<-acquired`, the unbuffered send has no receiver, `default` fires, the mutex is released, and the outer then waits forever on a channel no one will send to.

Reproducer hits roughly 3 hangs per ~2000 uncontended `Lock` calls on a multi-core machine. The race only fires when the runtime schedules the new goroutine onto another P fast enough to beat the parent into its select — common enough under `GOMAXPROCS > 1`.

Before #71 only `set`/`Delete` took the lock, so the cumulative race exposure per test run was small. #71 moved `Lock`/`Unlock` into every `api.Call`, multiplying the per-test opportunities to hit the race until at least one was virtually guaranteed.

The two observed symptoms match the same root cause:

- `terraform-provider-opnsense` acceptance tests survive but slow down — every operation has a `context.WithTimeout`, so a stuck `Lock` eventually returns `ctx.Err()` and the test continues.
- `opnsense-go`'s own integration tests pass `context.Background()`, so the same stuck `Lock` blocks until `go test`'s 10-minute timeout — tests hang rather than just dragging.

## Fix

Replace the `default:` with an `abandoned` channel the outer closes on ctx cancellation. The inner select now has no non-blocking escape: it either hands the lock off via `acquired`, or waits for the explicit abandon signal.

```go
acquired := make(chan struct{})
abandoned := make(chan struct{})
go func() {
    mu.Lock()
    select {
    case acquired <- struct{}{}:
    case <-abandoned:
        mu.Unlock()
    }
}()
select {
case <-acquired:
    return nil
case <-ctx.Done():
    close(abandoned)
    return ctx.Err()
}
```

Cancellation semantics are unchanged: a Lock that returns `ctx.Err()` releases the inner mutex as soon as it becomes acquirable, and the caller must still not call Unlock — matching the docstring already in place.

## Changes

- `pkg/api/mutexkv.go`: swap the racy `default:` for an `abandoned`-channel handoff.
- `pkg/api/mutexkv_test.go`: new regression — a 50k-iteration uncontended Lock/Unlock loop that hangs under the old impl, plus a ctx-cancellation timing check.

## Ordering

This should land before #70 / #71 / #72 / #73 — it's the root cause of the integration-test timeouts those branches inherited. Targeting `main` so it can ship standalone; the other PRs rebase cleanly on top.

## Test plan

- [x] `go build ./pkg/...` clean
- [x] `go vet ./pkg/...` clean
- [x] `go test ./pkg/api/...` passes, including the new 50k-iteration regression
- [x] Standalone reproducer: 3 hangs / ~2k iterations on the old impl, 0 / 100k on the new impl
- [ ] Integration tests against a live VM with `context.Background()` no longer time out (manual)