### PR TITLE
fix(routes): rename route disabled field to enabled for OPNsense 26.1.10+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,20 @@ When constructing a resource, assign the key directly: `Type: api.SelectedMap("h
 ### Monad wrapping
 OPNsense's API wraps request/response bodies in a top-level key (the "monad"). The schema `monad` field sets this key. `api.Add`/`api.Update` wrap outgoing structs; `api.Get` unwraps incoming responses automatically.
 
+### Renamed API fields (dual-key compatibility)
+When an OPNsense release renames a model field (e.g. 26.1.10 replaced the route model's `disabled` with `enabled`, opnsense/core#10027), do NOT swap the schema attribute — keep **both** attributes in the schema, one per JSON key:
+
+```yaml
+- name: Enabled     # new key (26.1.10+)
+  type: string
+  key: enabled
+- name: Disabled    # old key (pre-26.1.10)
+  type: string
+  key: disabled
+```
+
+OPNsense ignores unknown model fields, so a consumer that sets both fields on writes works on either side of the rename, and on reads exactly one field is populated — the consumer uses the new field and falls back to the old one when it is empty. No version detection needed. `pkg/routes` `Route.Enabled`/`Route.Disabled` is the reference example.
+
 ## Keeping AGENTS.md Up-to-Date
 
 Update this file whenever you make changes that affect how someone would work in this repo:

--- a/pkg/routes/route.go
+++ b/pkg/routes/route.go
@@ -21,6 +21,7 @@ var RouteOpts = api.ReqOpts{
 
 type Route struct {
 	Enabled     string          `json:"enabled"`
+	Disabled    string          `json:"disabled"`
 	Description string          `json:"descr"`
 	Gateway     api.SelectedMap `json:"gateway"`
 	Network     string          `json:"network"`

--- a/pkg/routes/route.go
+++ b/pkg/routes/route.go
@@ -20,7 +20,7 @@ var RouteOpts = api.ReqOpts{
 // Data structs
 
 type Route struct {
-	Disabled    string          `json:"disabled"`
+	Enabled     string          `json:"enabled"`
 	Description string          `json:"descr"`
 	Gateway     api.SelectedMap `json:"gateway"`
 	Network     string          `json:"network"`

--- a/schema/routes.yml
+++ b/schema/routes.yml
@@ -11,10 +11,15 @@ resources:
       update: "/routes/routes/setroute"
       delete: "/routes/routes/delroute"
     attrs:
+      # OPNsense 26.1.10 (core #10027) renamed this field from 'disabled'
+      # to 'enabled'. Enabled is the canonical field; Disabled is kept only
+      # for backwards compatibility with pre-26.1.10 releases. Consumers
+      # should write both (each version ignores the key it doesn't know)
+      # and read Enabled, falling back to Disabled when Enabled is empty.
       - name: Enabled
         type: string
         key: enabled
-      - name: Disabled
+      - name: Disabled # deprecated: pre-26.1.10 compatibility only
         type: string
         key: disabled
       - name: Description

--- a/schema/routes.yml
+++ b/schema/routes.yml
@@ -11,9 +11,9 @@ resources:
       update: "/routes/routes/setroute"
       delete: "/routes/routes/delroute"
     attrs:
-      - name: Disabled
+      - name: Enabled
         type: string
-        key: disabled
+        key: enabled
       - name: Description
         type: string
         key: descr

--- a/schema/routes.yml
+++ b/schema/routes.yml
@@ -14,6 +14,9 @@ resources:
       - name: Enabled
         type: string
         key: enabled
+      - name: Disabled
+        type: string
+        key: disabled
       - name: Description
         type: string
         key: descr


### PR DESCRIPTION
## Description

OPNsense 26.1.10 ([core #10027](https://github.com/opnsense/core/pull/10027), commit `3acfb5f2`) replaced the static-route model's `disabled` field (BooleanField, default `0`) with `enabled` (default `1`), including a config migration (`M1_0_1`).

Since that release the routes API:
- silently drops the `disabled` key on `addroute`/`setroute` — every route is created enabled regardless of the payload;
- omits `disabled` from `getroute` responses — the client decodes the Go zero value, so reads always look "not disabled".

This adds `Enabled` (`enabled`) to the Route schema **while keeping `Disabled` (`disabled`)**, so consumers can send both keys (OPNsense ignores unknown model fields — each version consumes the one it knows) and fall back on reads to whichever key the server populated. Works on both sides of the 26.1.10 rename with no version detection.

Verified against live VMs on both versions:
- 26.1.10: `addroute` with `{"disabled":"1"}` alone → saved but `getroute` returns `"enabled":"1"` (field ignored); with both keys → round-trips correctly.
- 26.1.9: both keys → `disabled` consumed, `enabled` ignored; round-trips correctly.

Non-breaking for existing consumers: `Route.Disabled` is retained; `Route.Enabled` added.

Downstream: terraform-provider-opnsense browningluke/terraform-provider-opnsense#156.
