### PR TITLE
feat(ci): shard integration tests across parallel VMs

### DIFF
--- a/.github/workflows/go-test-reusable.yml
+++ b/.github/workflows/go-test-reusable.yml
@@ -19,8 +19,100 @@ env:
   OPNSENSE_WEB_PORT: 8443
 
 jobs:
-  test:
+  plan:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Compute test shards
+        id: plan
+        env:
+          PACKAGES: ${{ inputs.packages }}
+        run: |
+          python3 << 'EOF'
+          import json, os, sys
+
+          # Each shard runs on its own runner with its own OPNsense VM, so
+          # shards run in parallel while tests within a shard stay serial.
+          # Long-running suites get a dedicated shard; everything else shares
+          # "other". Every pkg/<service> directory with integration tests MUST
+          # be assigned to a shard — the check below fails the run otherwise.
+          #
+          # Timing evidence from run 27878904613 (2026-06-20):
+          #   dnsmasq:  539s  → dedicated shard
+          #   ipsec:    226s  → dedicated shard
+          #   firewall: 166s  → dedicated shard
+          #   openvpn:   74s  → other
+          #   trust:     41s  → other
+          #   unbound:   39s  → other
+          #   kea:       32s  → other
+          #   cron:      21s  → other
+          #   auth:      14s  → other
+          #   interfaces:12s  → other
+          #   wireguard:  3s  → other
+          #   api:       <1s  → other (unit tests only, no VM needed)
+          SHARDS = {
+              "dnsmasq":  ["dnsmasq"],
+              "ipsec":    ["ipsec"],
+              "firewall": ["firewall"],
+              "other":    ["api", "auth", "bind", "core", "cron", "diagnostics",
+                           "dyndns", "interfaces", "kea", "openvpn", "quagga",
+                           "routes", "trust", "unbound", "wireguard"],
+          }
+          # pkg/ directories that are infrastructure/generated — excluded from
+          # the must-be-assigned check because they are not OPNsense services.
+          NON_SERVICE = {"errs", "opnsense"}
+
+          assigned = {p for pkgs in SHARDS.values() for p in pkgs}
+          on_disk = {d for d in os.listdir("pkg")
+                     if os.path.isdir(os.path.join("pkg", d))}
+          service_pkgs = on_disk - NON_SERVICE
+          unassigned = sorted(service_pkgs - assigned)
+          if unassigned:
+              sys.exit("pkg/ service packages not assigned to any shard: "
+                       f"{unassigned}. Add them to SHARDS in "
+                       ".github/workflows/go-test-reusable.yml.")
+
+          requested = os.environ["PACKAGES"].split()
+          matrix = []
+          if requested == ["./..."]:
+              for name, pkgs in SHARDS.items():
+                  paths = [f"./pkg/{p}/..." for p in pkgs]
+                  matrix.append({"name": name, "packages": " ".join(paths)})
+          else:
+              services = []
+              for path in requested:
+                  parts = path.split("/")
+                  if parts[:1] != ["."] or parts[1:2] != ["pkg"] or len(parts) < 4:
+                      sys.exit(f"unexpected package path: {path}")
+                  services.append(parts[2])
+              unknown = sorted(set(services) - assigned)
+              if unknown:
+                  sys.exit(f"requested packages not assigned to any shard: {unknown}")
+              for name, pkgs in SHARDS.items():
+                  hit = [p for p in pkgs if p in services]
+                  if hit:
+                      matrix.append({"name": name,
+                                     "packages": " ".join(f"./pkg/{p}/..." for p in hit)})
+
+          if not matrix:
+              sys.exit("no test shards matched the requested packages")
+          print(json.dumps(matrix, indent=2))
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write("matrix=" + json.dumps(matrix) + "\n")
+          EOF
+
+  test:
+    name: test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs:
+      - plan
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -89,7 +181,7 @@ jobs:
         run: python3 scripts/configure-opnsense.py
 
       - name: Run tests
-        run: go test -p 1 -v -timeout 120m ${{ inputs.packages }}
+        run: go test -p 1 -v -timeout 120m ${{ matrix.packages }}
 
       - name: Stop opnsense VM
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Edit `schema/<service>.yml`, then run `make all`. The `generate.go` in every ser
 2. Create `pkg/<service>/generate.go` with the `//go:generate` directive (copy from any existing service).
 3. Run `make all`.
 
+CI runs the integration suite as parallel shards — one runner + one OPNsense VM per shard, defined in the `SHARDS` map in the `plan` job of `.github/workflows/go-test-reusable.yml`. **If you add a new `pkg/<service>` package, you must assign it to a shard there** (usually the `other` bucket; give it a dedicated shard if its suite runs long). The `plan` job fails the build if a service package is unassigned.
+
 ### Schema YAML structure
 - `resources` block → CRUD resources. Each resource becomes `Add<Name>`, `Get<Name>`, `Update<Name>`, `Delete<Name>` methods.
   - `readOnly: true` — omits Add/Update/Delete.


### PR DESCRIPTION
## Description

Stacked on #84 (contains that commit until it merges).

Splits the integration suite into parallel matrix shards — one runner with one OPNsense VM per shard — so suites that are slow in isolation no longer serialize against everything else.

**Shard map** (based on run 27878904613, 2026-06-20):

| Shard | Packages | ~Runtime |
|-------|----------|----------|
| `dnsmasq` | `dnsmasq` | 539s |
| `ipsec` | `ipsec` | 226s |
| `firewall` | `firewall` | 166s |
| `other` | everything else | ~74s (openvpn, the longest) |

Wall-clock drops from the full-suite serial ~15 min to the slowest shard (~9 min including VM boot).

A `plan` job computes the shard matrix from a `SHARDS` dict in an inline Python script. It:
- maps the `packages` workflow input onto shards (so Tier 1's changed-package detection still narrows what runs)
- fails the build if any `pkg/<service>` directory is not assigned to a shard (tripwire against silently untested packages)

`fail-fast: false` so a flaky shard doesn't cancel the rest.

AGENTS.md now documents that new service packages must be assigned to a shard.

The same pattern landed in terraform-provider-opnsense as PR #155.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open(...))"` on the changed workflow — passes
- `actionlint` on the changed workflow — no errors
- Plan script exercised locally with three inputs:
  - `./...` → 4-shard matrix as expected
  - `./pkg/firewall/... ./pkg/unbound/...` → firewall shard + other shard (unbound)
  - unassigned package → exits non-zero with clear error message