### PR TITLE
fix(ci): assign monit and syslog packages to test shard

### DIFF
--- a/.github/workflows/go-test-reusable.yml
+++ b/.github/workflows/go-test-reusable.yml
@@ -53,13 +53,15 @@ jobs:
           #   interfaces:12s  → other
           #   wireguard:  3s  → other
           #   api:       <1s  → other (unit tests only, no VM needed)
+          #   monit, syslog: added in #81, not yet timed → other
           SHARDS = {
               "dnsmasq":  ["dnsmasq"],
               "ipsec":    ["ipsec"],
               "firewall": ["firewall"],
               "other":    ["api", "auth", "bind", "core", "cron", "diagnostics",
-                           "dyndns", "interfaces", "kea", "openvpn", "quagga",
-                           "routes", "trust", "unbound", "wireguard"],
+                           "dyndns", "interfaces", "kea", "monit", "openvpn",
+                           "quagga", "routes", "syslog", "trust", "unbound",
+                           "wireguard"],
           }
           # pkg/ directories that are infrastructure/generated — excluded from
           # the must-be-assigned check because they are not OPNsense services.


### PR DESCRIPTION
## Summary
- PR #81 added `pkg/monit` and `pkg/syslog` but didn't register them in the CI shard map, so the `plan` job's must-be-assigned check fails every run since (e.g. run 30524519100).
- Adds both packages to the `other` shard bucket.

## Test plan
- [x] Verified locally that `on_disk` service packages exactly match the assigned set in `SHARDS`, so the plan job's unassigned-package check passes.
- [ ] CI run on this PR should show the `plan` job succeeding.