### PR TITLE
fix(ci): run Tier 2 tests when pipeline workflow files change

### DIFF
--- a/.github/workflows/go-test-pr.yml
+++ b/.github/workflows/go-test-pr.yml
@@ -37,15 +37,18 @@ jobs:
           # Check for any Go source or module file changes
           GO_FILES=$(echo "$ALL_CHANGED" | grep '\.go$' || true)
           MOD_CHANGED=$(echo "$ALL_CHANGED" | grep -E '^go\.(mod|sum)$' || true)
+          # Test pipeline itself: an edit here changes what "passing CI" means,
+          # so it must run the full suite rather than being skipped as a non-Go change.
+          PIPELINE_CHANGED=$(echo "$ALL_CHANGED" | grep -E '^\.github/workflows/go-test-(pr|reusable)\.yml$' || true)
 
-          if [ -z "$GO_FILES" ] && [ -z "$MOD_CHANGED" ]; then
+          if [ -z "$GO_FILES" ] && [ -z "$MOD_CHANGED" ] && [ -z "$PIPELINE_CHANGED" ]; then
             echo "No Go files changed — skipping tests"
             echo "packages=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [ -n "$MOD_CHANGED" ]; then
-            echo "go.mod/go.sum changed — running full suite"
+          if [ -n "$MOD_CHANGED" ] || [ -n "$PIPELINE_CHANGED" ]; then
+            echo "go.mod/go.sum or test pipeline changed — running full suite"
             echo "packages=./..." >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -8,6 +8,8 @@ on:
       - 'scripts/**'
       - 'README.md'
       - '.github/**'
+      - '!.github/workflows/go-test.yml'
+      - '!.github/workflows/go-test-reusable.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Two related gaps where editing the test pipeline itself doesn't actually get validated:

- **Tier 2** (`go-test.yml`, push to `main`): had `paths-ignore: '.github/**'`, so a commit that only edits a workflow file never triggers it at all. Confirmed via `gh run list` — #88 (the shard-map fix) merged and Tier 2 never ran for that commit.
- **Tier 1** (`go-test-pr.yml`, pull_request): the trigger itself does fire on workflow edits, but `detect-changes` only looks at `.go`/`go.mod`/`go.sum` diffs, so it reports "no Go files changed" and the `test` job's `if:` skips — confirmed #88's own Tier 1 run completed in 0s, never actually running tests. The pipeline change that caused the original incident (unassigned monit/syslog shards) went completely unexercised pre-merge.

## Fix
- `go-test.yml`: negate `go-test.yml`/`go-test-reusable.yml` back out of the `.github/**` ignore, mirroring the include-list `go-test-pr.yml` already uses.
- `go-test-pr.yml`: treat a diff touching `go-test-pr.yml` or `go-test-reusable.yml` the same as a `go.mod`/`go.sum` change — run the full suite instead of skipping.

Rest of `.github/**` (issue templates, other workflows, CODEOWNERS) stays ignored/unaffected in both cases.

## Test plan
- [x] YAML parses for both files.
- [x] Simulated `detect-changes` bash logic locally against a pipeline-only diff — now resolves to "run full suite" instead of "skip".
- [ ] Merge and confirm a follow-up pipeline-only commit to `main` triggers both Tier 1 (on its PR) and Tier 2 (on merge).