### PR TITLE
firewall: add StaticPort to the NAT model

### DIFF
--- a/pkg/firewall/nat.go
+++ b/pkg/firewall/nat.go
@@ -34,6 +34,7 @@ type NAT struct {
 	DestinationInvert string          `json:"destination_not"`
 	Target            string          `json:"target"`
 	TargetPort        string          `json:"target_port"`
+	StaticPort        string          `json:"staticnatport"`
 	Log               string          `json:"log"`
 	Description       string          `json:"description"`
 }

--- a/schema/firewall.yml
+++ b/schema/firewall.yml
@@ -215,6 +215,9 @@ resources:
       - name: TargetPort
         type: string
         key: target_port
+      - name: StaticPort
+        type: string
+        key: staticnatport
       - name: Log
         type: string
         key: log


### PR DESCRIPTION
The source_nat API exposes a `staticnatport` field, which prevents the firewall from modifying the source port on TCP and UDP packets. The `NAT` struct had no field for it, so it could not be set.

Added to `schema/firewall.yml` between `TargetPort` and `Log`. `pkg/firewall/nat.go` regenerated with `go generate`.

### On testing

I initially added `StaticPort` coverage to `TestNAT` and CI failed with `got , want 1`. The cause is the test VM image, not the change: `staticnatport` was added to the `snatrules` section of the OPNsense `Filter.xml` model in **26.1.5**, and the pipeline boots `opnsense-26.1.qcow2`.

| tag | `staticnatport` in model |
|---|---|
| 26.1, 26.1.1 - 26.1.4 | absent |
| 26.1.5, 26.1.6, 26.7.x | present |

OPNsense silently drops unknown fields on POST, so on the CI image the value round-trips as empty and the assertion cannot pass. The struct change is still safe there, since an absent key decodes to `""`.

I reverted the test change to keep this PR focused. Happy to add coverage if the image is bumped to 26.1.5 or later.

Verified manually against 26.1.5+, including the exact create-then-update sequence `TestNAT` uses:

```
create staticnatport=0, update to 1  -> reads back "1"
target_port=9090 + staticnatport=1   -> both persist
```