### PR TITLE
dnsmasq: add missing fields in host and general settings, fix  range fields

### DIFF
--- a/pkg/dnsmasq/general.go
+++ b/pkg/dnsmasq/general.go
@@ -15,12 +15,16 @@ type GeneralDHCPSettings struct {
 	InterfaceNoDhcp       api.SelectedMapList `json:"no_interface"`
 	FQDN                  string              `json:"fqdn"`
 	DefaultDomain         string              `json:"domain"`
+	LocalDomain           string              `json:"local"`
 	MaxLeases             string              `json:"lease_max"`
 	Authoritative         string              `json:"authoritative"`
 	ReplyDelay            string              `json:"reply_delay"`
 	RegisterFirewallRules string              `json:"default_fw_rules"`
 	RouterAdvertisements  string              `json:"enable_ra"`
+	HostPing              string              `json:"host_ping"`
 	DisableHASync         string              `json:"nosync"`
+	LogDhcp               string              `json:"log_dhcp"`
+	LogQuiet              string              `json:"log_quiet"`
 }
 
 type GeneralSettings struct {

--- a/pkg/dnsmasq/general_test.go
+++ b/pkg/dnsmasq/general_test.go
@@ -42,7 +42,9 @@ func TestGeneral(t *testing.T) {
 		DHCPSettings: GeneralDHCPSettings{
 			FQDN:                  "1",
 			RegisterFirewallRules: "1",
-			DisableHASync:         "1", // New setting to set without breaking anything
+			DisableHASync:         "1", 
+			LocalDomain:           "1",
+			HostPing:              "1",
 		},
 	}
 
@@ -71,7 +73,9 @@ func TestGeneral(t *testing.T) {
 		DHCPSettings: GeneralDHCPSettings{
 			FQDN:                  "1",
 			RegisterFirewallRules: "1",
-			DisableHASync:         "0", // New setting to set without breaking anything
+			DisableHASync:         "0", 
+			LocalDomain:           "0",
+			HostPing:              "1",
 		},
 	}
 

--- a/pkg/dnsmasq/host.go
+++ b/pkg/dnsmasq/host.go
@@ -28,6 +28,7 @@ type Host struct {
 	CnameRecords      api.SelectedMapList `json:"cnames"`
 	ClientId          string              `json:"client_id"`
 	HardwareAddresses api.SelectedMapList `json:"hwaddr"`
+	LeaseTime         string              `json:"lease_time"`
 	Tag               api.SelectedMap     `json:"set_tag"`
 	IsIgnored         string              `json:"ignore"`
 	Description       string              `json:"descr"`

--- a/pkg/dnsmasq/host_test.go
+++ b/pkg/dnsmasq/host_test.go
@@ -58,6 +58,7 @@ func TestHost(t *testing.T) {
 	host.AliasRecords = api.SelectedMapList([]string{"test-alias-1", "test-alias-2"})
 	host.CnameRecords = api.SelectedMapList([]string{"test-cname-1", "test-cname-2"})
 	host.HardwareAddresses = api.SelectedMapList([]string{"00:11:22:33:44:55", "AA:BB:CC:DD:EE:FF"})
+	host.LeaseTime = "43200"
 	// host.Tagset = api.SelectedMap("ee791e64-69de-4776-a9a0-e1442630c6ef")
 	err = controller.UpdateHost(ctx, respAdd, host)
 	if err != nil {
@@ -92,6 +93,9 @@ func TestHost(t *testing.T) {
 		}
 		if v.HardwareAddresses != host.HardwareAddresses.String() {
 			t.Fatalf("Hardware addresses not updated; Got: %s Expected: %s", v.HardwareAddresses, host.HardwareAddresses.String())
+		}
+		if v.LeaseTime != host.LeaseTime {
+			t.Fatalf("LeaseTime not updated; Got: %s Expected: %s", v.LeaseTime, host.LeaseTime)
 		}
 	}
 	if noRowFound {

--- a/pkg/dnsmasq/integration_test.go
+++ b/pkg/dnsmasq/integration_test.go
@@ -75,7 +75,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	optionTwo.TypeMatchTag = api.SelectedMap(tagOneId)
-	controller.UpdateOption(ctx, optionTwoId, optionTwo)
+	err = controller.UpdateOption(ctx, optionTwoId, optionTwo)
 	if err != nil {
 		t.Fatalf("Error updating: %+v; %s", optionTwo, err)
 	}

--- a/pkg/dnsmasq/option_test.go
+++ b/pkg/dnsmasq/option_test.go
@@ -56,7 +56,7 @@ func TestOption(t *testing.T) {
 	option.OptionV6 = api.SelectedMap("23")
 	// option.Tag = nil
 	// option.TagSet = api.SelectedMap("763bd6ed-e6bc-4c3c-aef7-6fef954179a5")
-	option.Value = "255.255.255.250"
+	option.Value = "[2001:db8:abcd:0012::1]"
 	option.Description = "test-subnetmask-updated"
 	err = controller.UpdateOption(ctx, respAdd, option)
 	if err != nil {

--- a/pkg/dnsmasq/range.go
+++ b/pkg/dnsmasq/range.go
@@ -20,24 +20,24 @@ var RangeOpts = api.ReqOpts{
 // Data structs
 
 type Range struct {
-	Interface        api.SelectedMap `json:"interface"`
-	Tag              api.SelectedMap `json:"set_tag"`
-	StartAddress     string          `json:"start_addr"`
-	EndAddress       string          `json:"end_addr"`
-	SubnetMask       string          `json:"subnet_mask"`
-	Constructor      api.SelectedMap `json:"constructor"`
-	Mode             api.SelectedMap `json:"mode"`
-	PrefixLength     string          `json:"prefix_len"`
-	LeaseTime        string          `json:"lease_time"`
-	DomainType       api.SelectedMap `json:"domain_type"`
-	Domain           string          `json:"domain"`
-	DisableHASync    string          `json:"nosync"`
-	RaMode           api.SelectedMap `json:"ra_mode"`
-	RaPriority       api.SelectedMap `json:"ra_priority"`
-	RaMTU            string          `json:"ra_mtu"`
-	RaInterval       string          `json:"ra_interval"`
-	RaRouterLifetime string          `json:"ra_router_lifetime"`
-	Description      string          `json:"description"`
+	Interface        api.SelectedMap     `json:"interface"`
+	Tag              api.SelectedMap     `json:"set_tag"`
+	StartAddress     string              `json:"start_addr"`
+	EndAddress       string              `json:"end_addr"`
+	SubnetMask       string              `json:"subnet_mask"`
+	Constructor      api.SelectedMap     `json:"constructor"`
+	Mode             api.SelectedMapList `json:"mode"`
+	PrefixLength     string              `json:"prefix_len"`
+	LeaseTime        string              `json:"lease_time"`
+	DomainType       api.SelectedMap     `json:"domain_type"`
+	Domain           string              `json:"domain"`
+	DisableHASync    string              `json:"nosync"`
+	RaMode           api.SelectedMapList `json:"ra_mode"`
+	RaPriority       api.SelectedMap     `json:"ra_priority"`
+	RaMTU            string              `json:"ra_mtu"`
+	RaInterval       string              `json:"ra_interval"`
+	RaRouterLifetime string              `json:"ra_router_lifetime"`
+	Description      string              `json:"description"`
 }
 
 // CRUD operations

--- a/pkg/dnsmasq/range_test.go
+++ b/pkg/dnsmasq/range_test.go
@@ -28,83 +28,123 @@ func TestRange(t *testing.T) {
 	}
 	ctx := context.Background()
 
+	expectedMode := api.SelectedMapList([]string{
+		"static",
+	})
 	rng := &Range{
 		StartAddress: "192.168.100.100",
-		EndAddress:   "192.168.100.199",
 		DomainType:   api.SelectedMap("range"),
+		Mode:         expectedMode,
+		Description:  "test-description",
 	}
 
-	respAdd, err := controller.AddRange(ctx, rng)
+	respId, err := controller.AddRange(ctx, rng)
 	if err != nil {
 		t.Fatalf("Failed to add range: %v", err)
 	}
-	t.Logf("AddRange: %+v", respAdd)
+	t.Logf("AddRange: %+v", respId)
 
-	respGet, err := controller.GetRange(ctx, respAdd)
+	// Cleanup is only used if the test fails before the explicit delete.
+	deleted := false
+
+	t.Cleanup(func() {
+		if deleted {
+			return
+		}
+
+		if err := controller.DeleteRange(ctx, respId); err != nil {
+			t.Errorf("Failed to cleanup range: %v", err)
+		}
+	})
+
+	v, err := controller.GetRange(ctx, respId)
 	if err != nil {
 		t.Fatalf("Failed to get range: %v", err)
 	}
-	t.Logf("GetRange: %+v", respGet)
+	t.Logf("GetRange: %+v", v)
 
-	// rng.Interface = api.SelectedMap("lan")
-	// rng.Tags = api.SelectedMap("d594fa8a-1a76-44e7-afab-adb6c5bdb69e")
-	rng.StartAddress = "192.168.100.200"
-	rng.EndAddress = "192.168.100.250"
-	rng.SubnetMask = "255.255.255.224"
-	// rng.Constructor = api.SelectedMap("lan")
-	// rng.Mode = api.SelectedMap("static")
-	rng.LeaseTime = "3600"
-	rng.Domain = "test-domain-updated"
-	rng.DisableHASync = "1"
+	if v.StartAddress != rng.StartAddress {
+		t.Fatalf("StartAddress not equal; Got: %q Expected: %q", v.StartAddress, rng.StartAddress)
+	}
+
+	if v.EndAddress != "" {
+		t.Fatalf("EndAddress must be empty for static range; Got: %q", v.EndAddress)
+	}
+
+	if v.SubnetMask != "" {
+		t.Fatalf("SubnetMask must be empty for static range; Got: %q", v.SubnetMask)
+	}
+
+	if v.DomainType.String() != rng.DomainType.String() {
+		t.Fatalf("DomainType not equal; Got: %q Expected: %q", v.DomainType.String(), rng.DomainType.String())
+	}
+
+	if v.Description != rng.Description {
+		t.Fatalf("Description not equal; Got: %q Expected: %q", v.Description, rng.Description)
+	}
+
+	// ---------------------------------------------------------------------
+	// Verify SelectedMapList round-trip.
+	// ---------------------------------------------------------------------
+
+	if len(v.Mode) != 1 {
+		t.Fatalf("Mode contains unexpected number of values; Got: %+v Expected: %+v", v.Mode, expectedMode)
+	}
+
+	if v.Mode[0] != "static" {
+		t.Fatalf("Mode not equal; Got: %+v Expected: %+v", v.Mode, expectedMode)
+	}
+
+	// ---------------------------------------------------------------------
+	// Update static range.
+	//
+	// Do NOT specify EndAddress or SubnetMask.
+	// ---------------------------------------------------------------------
+	rng.StartAddress = "192.168.100.101"
 	rng.Description = "test-description-updated"
-	err = controller.UpdateRange(ctx, respAdd, rng)
+	rng.Mode = api.SelectedMapList([]string{"static"})
+	err = controller.UpdateRange(ctx, respId, rng)
 	if err != nil {
 		t.Fatalf("Failed to update range: %v", err)
 	}
 	t.Logf("UpdateRange: %+v", rng)
 
-	respSearch, err := controller.SearchRange(ctx, "-1")
+	// ---------------------------------------------------------------------
+	// GET after update
+	// ---------------------------------------------------------------------
+	v, err = controller.GetRange(ctx, respId)
 	if err != nil {
-		t.Fatalf("Failed to search ranges: %v", err)
+		t.Fatalf("Failed to get range after update: %v", err)
 	}
-	t.Logf("SearchRange: %+v", respSearch)
-	noRowFound := true
-	lastId := ""
-	for _, v := range respSearch.Rows {
-		lastId = v.Id
-		if v.Id != respAdd {
-			continue
-		}
-		noRowFound = false
-		if v.StartAddress != rng.StartAddress {
-			t.Fatalf("StartAddress not updated; Got: %s Expected: %s", v.StartAddress, rng.StartAddress)
-		}
-		if v.EndAddress != rng.EndAddress {
-			t.Fatalf("EndAddress not updated; Got: %s Expected: %s", v.EndAddress, rng.EndAddress)
-		}
-		if v.SubnetMask != rng.SubnetMask {
-			t.Fatalf("SubnetMask not updated; Got: %s Expected: %s", v.SubnetMask, rng.SubnetMask)
-		}
-		if v.LeaseTime != rng.LeaseTime {
-			t.Fatalf("LeaseTime not updated; Got: %s Expected: %s", v.LeaseTime, rng.LeaseTime)
-		}
-		if v.Domain != rng.Domain {
-			t.Fatalf("Domain not updated; Got: %s Expected: %s", v.Domain, rng.Domain)
-		}
-		if v.DisableHASync != rng.DisableHASync {
-			t.Fatalf("DisableHASync not updated; Got: %s Expected: %s", v.DisableHASync, rng.DisableHASync)
-		}
-		if v.Description != rng.Description {
-			t.Fatalf("Description not updated; Got: %s Expected: %s", v.Description, rng.Description)
-		}
+	t.Logf("GetRange after update: %+v", v)
+
+	if v.StartAddress != rng.StartAddress {
+		t.Fatalf("StartAddress not updated; Got: %q Expected: %q", v.StartAddress, rng.StartAddress)
 	}
-	if noRowFound {
-		t.Fatalf("Row not found that was added; Got: %s Expected: %s", lastId, respAdd)
+	if v.EndAddress != "" {
+		t.Fatalf("EndAddress must remain empty for static range; Got: %q", v.EndAddress)
+	}
+	if v.SubnetMask != "" {
+		t.Fatalf("SubnetMask must remain empty for static range; Got: %q", v.SubnetMask)
+	}
+	if v.Description != rng.Description {
+		t.Fatalf("Description not updated; Got: %q Expected: %q", v.Description, rng.Description)
+	}
+	if len(v.Mode) != 1 {
+		t.Fatalf("Mode contains unexpected number of values after update; Got: %+v Expected: %+v", v.Mode, rng.Mode)
+	}
+	if v.Mode[0] != "static" {
+		t.Fatalf("Mode not updated; Got: %+v Expected: %+v", v.Mode, rng.Mode)
 	}
 
-	err = controller.DeleteRange(ctx, respAdd)
+	// ---------------------------------------------------------------------
+	// Delete
+	// ---------------------------------------------------------------------
+
+	err = controller.DeleteRange(ctx, respId)
 	if err != nil {
 		t.Fatalf("Failed to delete range: %v", err)
 	}
+	deleted = true
 	t.Log("DeleteRange: Deleted!")
 }

--- a/schema/dnsmasq.yml
+++ b/schema/dnsmasq.yml
@@ -37,6 +37,9 @@ resources:
       - name: HardwareAddresses
         type: SelectedMapList
         key: hwaddr
+      - name: LeaseTime
+        type: string
+        key: lease_time
       - name: Tag
         type: SelectedMap
         key: set_tag

--- a/schema/dnsmasq.yml
+++ b/schema/dnsmasq.yml
@@ -114,7 +114,7 @@ resources:
         type: SelectedMap
         key: constructor
       - name: Mode
-        type: SelectedMap
+        type: SelectedMapList
         key: mode
       - name: PrefixLength
         type: string
@@ -132,7 +132,7 @@ resources:
         type: string
         key: nosync
       - name: RaMode
-        type: SelectedMap
+        type: SelectedMapList
         key: ra_mode
       - name: RaPriority
         type: SelectedMap
@@ -703,6 +703,9 @@ rpc:
       - name: DefaultDomain
         type: string
         key: domain
+      - name: LocalDomain
+        type: string
+        key: local
       - name: MaxLeases
         type: string
         key: lease_max
@@ -718,6 +721,15 @@ rpc:
       - name: RouterAdvertisements
         type: string
         key: enable_ra
+      - name: HostPing
+        type: string
+        key: host_ping
       - name: DisableHASync
         type: string
         key: nosync
+      - name: LogDhcp
+        type: string
+        key: log_dhcp
+      - name: LogQuiet
+        type: string
+        key: log_quiet


### PR DESCRIPTION
The `dnsmasq host` API exposes a `lease_time` field to define the DHCP lease time in seconds. The field was missing from the `dnsmasq` host schema.

Added `LeaseTime` to `schema/dnsmasq.yml` and regenerated the affected code with `make all`.

### Testing

I added coverage for the new field to `pkg/dnsmasq/host_test.go` and verified the host create/update flow against:

* a local test image from [[browningluke/opnsense-images#3](https://github.com/browningluke/opnsense-images/pull/3)](https://github.com/browningluke/opnsense-images/pull/3)
* my local OPNsense instance

Both test environments are running OPNsense *26.7.3_8*.

The following acceptance test was executed successfully:

```bash
make testacc PKG=dnsmasq TEST=TestHost
```

### Follow-up

An additional Terraform provider PR will consume this field.