### PR TITLE
fix(wireguard): add the missing servers field to Client

### DIFF
--- a/pkg/wireguard/client.go
+++ b/pkg/wireguard/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	ServerAddress string              `json:"serveraddress"`
 	ServerPort    string              `json:"serverport"`
 	KeepAlive     string              `json:"keepalive"`
+	Servers       api.SelectedMapList `json:"servers"`
 }
 
 // CRUD operations

--- a/schema/wireguard.yml
+++ b/schema/wireguard.yml
@@ -85,6 +85,9 @@ resources:
       - name: KeepAlive
         type: string
         key: keepalive
+      - name: Servers
+        type: SelectedMapList
+        key: servers
 
 rpc:
   - name: General


### PR DESCRIPTION
OPNsense stores the peer-to-instance relationship on the client, in a `servers` field, and returns it from `getClient`:

```
fields: enabled, endpoint, keepalive, name, privkey, psk, pubkey,
        serveraddress, serverport, servers, tunneladdress
servers: selected=['<server-uuid>']
```

The generated `Client` struct omits it, so the value is never read and never sent back on `setClient`. OPNsense treats the absent field as empty and clears the association, detaching the peer from its instance. `Server` already carries the mirror image as `Peers`, so this only makes the two sides symmetric.

The change is in `schema/wireguard.yml`; `pkg/wireguard/client.go` is the regenerated output.

Context: browningluke/terraform-provider-opnsense#188. There, a plain update of an `opnsense_wireguard_client` silently drops the peer and leaves the tunnel transmitting but not receiving, which only shows up as a dead gateway rather than an error.

This is the SDK half. The provider needs a matching change to actually preserve the value, which I will raise separately once you have said whether you would rather expose `servers` on the client resource or simply carry it through on update.
